### PR TITLE
Requests version

### DIFF
--- a/champss/sps-ops/pyproject.toml
+++ b/champss/sps-ops/pyproject.toml
@@ -15,6 +15,7 @@ click = "^8.1.4"
 pandas = "^2.0.3"
 matplotlib = "^3.7.1"
 pymongo = "^4.4.0"
+requests = "<2.32.0"
 
 [tool.poetry.group.dev.dependencies]
 commitizen = "^3.4.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2679,13 +2679,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.2"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
-    {file = "requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
@@ -3024,6 +3024,7 @@ matplotlib = "^3.7.1"
 pandas = "^2.0.3"
 prometheus-api-client = "^0.5.4"
 pymongo = "^4.4.0"
+requests = "<2.32.0"
 
 [package.source]
 type = "directory"


### PR DESCRIPTION
Cap requests version, as a recent change lead to docker URL errors:  https://github.com/psf/requests/issues/6707

I'm not sure if this is needed long-term, but it is a short-term fix to avoid upstream issues