### PR TITLE
Allow alternate config name

### DIFF
--- a/champss/pipeline_batch_db/sps_pipeline/pipeline.py
+++ b/champss/pipeline_batch_db/sps_pipeline/pipeline.py
@@ -54,8 +54,7 @@ def load_config(config_file="sps_config.yml"):
     """
     Combines default/user-specified config settings and applies them to loggers.
 
-    User-specified settings can be given in two forms: as a YAML file in the
-    current directory, or as command-line arguments.
+    User-specified settings are given as a YAML file in the current directory.
 
     The format of the file is (all sections optional):
     ```


### PR DESCRIPTION
This allows the usage of alternate configs. 

The docstring also mentions that the config values can be set using the command line which I don't think is in the code currently. Is this something we should look into adding?