### PR TITLE
Address bugs

### DIFF
--- a/champss/pipeline_batch_db/sps_pipeline/workflow.py
+++ b/champss/pipeline_batch_db/sps_pipeline/workflow.py
@@ -243,6 +243,7 @@ def schedule_workflow_job(
             f"Failed to login to DockerHub to schedule {docker_name}: {error}."
             " Will not schedule this task."
         )
+        return ""
 
     workflow_site = "chime"
     workflow_user = "CHAMPSS"
@@ -339,6 +340,7 @@ def schedule_workflow_job(
             f"Failed to deposit Work and create Docker Service for {docker_name}: {error}."
             " Will not schedule this task."
         )
+        return ""
 
 
 @click.command()


### PR DESCRIPTION
Adds a bunch of try/excepts everywhere from schedule_workflow_job so that a whole day's of processing isn't stopped by a benign error, such as when waiting for no pending/running tasks, when a Docker service's CreatedAt attribute is missing the microseconds field, DockerHub fails, Workflow API goes down, etc. Additionally, if a Workflow runner has been in "running" state for more its timeout time (40 minutes) * 2 (we allow one retry in our Work object definition), then we will force kill it (and still dump the multiprocessing logs). 