### PR TITLE
Constrain /data/ mounts to sps-archiver1.chime

### DIFF
--- a/champss/pipeline_batch_db/sps_pipeline/workflow.py
+++ b/champss/pipeline_batch_db/sps_pipeline/workflow.py
@@ -282,9 +282,20 @@ def schedule_workflow_job(
             mount_paths = mount_path.split(":")
             mount_source = mount_paths[0]
             mount_target = mount_paths[1]
+            mount_driver = docker.types.DriverConfig(
+                name=None,
+                options={
+                    "type": "nfs",
+                    "o": "addr=10.17.4.21,nfsvers=4.0,rw,noatime,nodiratime,soft",
+                    "device": f":{mount_source}",
+                },
+            )
             docker_volumes.append(
                 docker.types.Mount(
-                    target=mount_target, source=mount_source, type="bind"
+                    source=None,
+                    target=mount_target,
+                    type="volume",
+                    driver_config=mount_driver,
                 )
             )
 


### PR DESCRIPTION
This should constrain all mounts from /data/ to Workflow containers to use the /data/ on sps-archiver1's VLAN17 IP (10.17.4.21). So, no matter where `schedule_workflow_job` is run from, it will not go through hops to get to the original /data/ source. 