### PR TITLE
Change candidate file writing to facilitate faster single candidate retrieval

### DIFF
--- a/champss/sps-common/sps_common/interfaces/multi_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/multi_pointing.py
@@ -17,7 +17,6 @@ from sps_common.constants import (
 )
 from sps_common.interfaces.single_pointing import (
     SinglePointingCandidate,
-    SinglePointingCandidateCollection,
 )
 from sps_common.interfaces.utilities import within_range
 from sps_common.plotting import plot_candidate
@@ -285,7 +284,7 @@ class MultiPointingCandidate:
     # @best_freq_arr.validator
     # @best_dm_arr.validator
     def _check_array(self, attribute, value):
-        if type(value) != np.ndarray:
+        if type(value) is not np.ndarray:
             raise TypeError(
                 f"The array ({attribute.name}={value}) is must be a numpy.ndarray"
             )
@@ -328,7 +327,7 @@ class MultiPointingCandidate:
     # @features.validator
     @position_features.validator
     def _check_features(self, attribute, value):
-        if type(value) != np.ndarray:
+        if type(value) is not np.ndarray:
             raise TypeError(
                 f"Feature attribute ({attribute.name}={value}) must be a numpy.ndarray"
             )
@@ -358,15 +357,15 @@ class MultiPointingCandidate:
             known_source_string += (
                 f"\n{source[0]} ({source[1]:.2f}, {source[2]:.2f}): {source[5]:.5f}"
             )
-            known_source_string += f"\n F0: {1/source[3]:.4f}, DM: {source[4]:.2f}"
+            known_source_string += f"\n F0: {1 / source[3]:.4f}, DM: {source[4]:.2f}"
         return known_source_string
 
     def single_candidate(self, index):
         """Load a SinglePointingCandidate based on an index."""
-        cand_collection = SinglePointingCandidateCollection.read(
-            self.all_summaries[index]["file_name"], verbose=False
+        candidate = SinglePointingCandidate.get_from_spcc(
+            self.all_summaries[index]["file_name"],
+            self.all_summaries[index]["cand_index"],
         )
-        candidate = cand_collection.candidates[self.all_summaries[index]["cand_index"]]
         return candidate
 
     @property


### PR DESCRIPTION
This PR includes the following minor changes:

- Changed spc.as_dict to just use spc.__ dict__ since this seems to work currently. I think the enumerate entries were a problem at some point, but in my current environment it worked without that
- Replaced hhat mentions with ffa in SearchAlgorithm
- Removed block used for backwards compatibility in spcc reading. That change was 3 years ago and I doubt anyone uses candidates this old with the current code.
- Fixed reading candidates twice in spcc.read. Apprently if you run `data["candidate_dicts"]` twice, when data is a npz file loaded with np.load, it will load the candidates twice.

The major change is the introduction of the `split_cands` argument in spcc.write. When this is used, the different candidates are saved separately into different keys of the npz file. Since `np.load` loads npz files lazily, this allows quick retrieval of individual candidates without loading all candidates. But when loading all candidates it is a bit slower. From my tests up to 50% but it is still faster than previously because of the double reading issue.

Whether this option is really used, depends on how often each files is read in which mode. 

From my parts of the pipeline I read all candidates during the multi pointing clustering, but I do not write the individual candidates into the mp candidates files, to not write redundant data. This would be slower with this option.
But as part of my ML efforts when I create test sets, I read sp candidates based on the mp candidates. In this case the new method is probably more than 10 times faster usually.
Are there any more reads of the sp candidates?

A picture illustrating the performance of full and partial reading of SinglePointingCandidateCollections based on the method.

![image](https://github.com/user-attachments/assets/27397079-c8e6-496f-ad8f-c24cc3640938)

Any thoughts?
