### PR TITLE
bug fix for when there is no nearby ks

### DIFF
--- a/champss/folding/folding/fold_candidate.py
+++ b/champss/folding/folding/fold_candidate.py
@@ -4,7 +4,6 @@ import subprocess
 
 import click
 import numpy as np
-import sys
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 
@@ -305,10 +304,10 @@ def main(
     day = date.day
 
     if dir_suffix == "candidates":
-        log.info(f"Setting up pointing for {round(ra, 2)} {round(dec, 2)}...")
-        coord_path = f"{directory_path}/{round(ra, 2)}_{round(dec, 2)}"
+        log.info(f"Setting up pointing for {ra:.02f} {dec:.02f}...")
+        coord_path = f"{directory_path}/{ra:.02f}_{dec:.02f}"
         archive_fname = (
-            f"{coord_path}/cand_{round(dm, 2)}_{round(f0, 2)}_{year}-{month:02}-{day:02}"
+            f"{coord_path}/cand_{f0:.02f}_{dm:.02f}_{year}-{month:02}-{day:02}"
         )
         if not os.path.exists(coord_path):
             os.makedirs(coord_path)
@@ -316,7 +315,7 @@ def main(
             log.info(f"Directory '{coord_path}' already exists.")
         if not ephem_path:
             ephem_path = (
-                f"{coord_path}/cand_{round(dm, 2)}_{round(f0, 2)}_{year}-{month:02}-{day:02}.par"
+                f"{coord_path}/cand_{f0:.02f}_{dm:.02f}_{year}-{month:02}-{day:02}.par"
             )
             create_ephemeris(name, ra, dec, dm, date, f0, ephem_path, fs_id)
     elif dir_suffix == "known_sources":
@@ -345,7 +344,9 @@ def main(
     for active_pointing in ap:
         data_list.extend(
             get_data_list(
-                active_pointing.max_beams, basepath="/data/chime/sps/raw/", extn="dat"
+                active_pointing.max_beams,
+                basepath="/mnt/beegfs-client/raw/",
+                extn="dat",
             )
         )
     if not data_list:
@@ -372,12 +373,12 @@ def main(
         turns = 10
 
     if not os.path.isfile(fil):
-        log.info(f"Beamforming...")
+        log.info("Beamforming...")
         sbf = SkyBeamFormer(
             extn="dat",
             update_db=False,
             min_data_frac=0.5,
-            basepath="/data/chime/sps/raw/",
+            basepath="/mnt/beegfs-client/raw/",
             add_local_median=True,
             detrend_data=True,
             detrend_nsamp=32768,
@@ -398,7 +399,9 @@ def main(
         )
         skybeam, spectra_shared = sbf.form_skybeam(ap[0], num_threads=num_threads)
         if skybeam is None:
-            log.info("Insufficient unmasked data to form skybeam, exiting before filterbank creation")
+            log.info(
+                "Insufficient unmasked data to form skybeam, exiting before filterbank creation"
+            )
             spectra_shared.close()
             spectra_shared.unlink()
             return

--- a/champss/folding/folding/plot_candidate.py
+++ b/champss/folding/folding/plot_candidate.py
@@ -334,7 +334,7 @@ def plot_candidate_archive(
         plotstring = f"{psr}_{T0.isot[:10]}.png"
         plotstring_radec = f"{psr}_{T0.isot[:10]}.png"
 
-    plt.savefig(coord_path + plotstring, dpi=fig.dpi, bbox_inches="tight")
+    plt.savefig(f'{coord_path}/{plotstring}', dpi=fig.dpi, bbox_inches="tight")
 
     img_path = f"{foldpath}/{T0.isot[:10]}-plots/"
     if not os.path.exists(img_path):


### PR DESCRIPTION
Small fix to catch when there are no nearby sources for the comparison table. Change filenames to cand_...png and psrname_...png for candidates vs known_sources (will improve the known source logic later)

Also some pre-commit changes