### PR TITLE
Fix folding bugs

### DIFF
--- a/champss/folding/folding/fold_candidate.py
+++ b/champss/folding/folding/fold_candidate.py
@@ -450,8 +450,8 @@ def main(
         ra,
         dec,
         coord_path,
-        known,
-        foldpath,
+        known=known,
+        foldpath=foldpath + "/plots/folded_candidate_plots/",
     )
 
     log.info(f"SN of folded profile: {SN_arr}")


### PR DESCRIPTION
There were two bugs that crashed the folding processes:

- plot_candidate_archive got some positional arguments which should be keyword arguments
- Filter tried to concatenate some empty arrays. I moved all the instances in the filter of np.argwhere().squeeze to np.flatnonzero and removed the loop from the index concatenation. Seems to work and is more easily understandable I think.