### PR TITLE
Make our re-usable GitHub Actions workflows use a local path...

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   update-image:
    # Create an image of your branch with the branch name as tag, and save it locally on the testbed since it'll only run there
-    uses: chime-sps/champss_software/.github/workflows/image.yml@main
+    uses: ./.github/workflows/image.yml
     secrets: inherit
     with:
       image_tag: ${{ inputs.branch_name || 'none' }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -8,12 +8,12 @@ on:
 jobs:
   # GitHub Actions fails if any "with" parameter is empty when using reusable workflows, so needs || fallbacks
   check-release:
-    uses: chime-sps/champss_software/.github/workflows/release.yml@main
+    uses: ./.github/workflows/release.yml
     secrets: inherit
   latest-image:
     needs: check-release
     if: ${{ !needs.check-release.outputs.release_created }}
-    uses: chime-sps/champss_software/.github/workflows/image.yml@main
+    uses: ./.github/workflows/image.yml
     secrets: inherit
     with:
       image_tag: 'latest'
@@ -21,7 +21,7 @@ jobs:
   version-image:
     needs: check-release
     if: ${{ needs.check-release.outputs.release_created == 'true' }}
-    uses: chime-sps/champss_software/.github/workflows/image.yml@main
+    uses: ./.github/workflows/image.yml
     secrets: inherit
     with:
       # E.g. v1.0.0, only set if merging automated release PR

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,18 +14,18 @@ jobs:
   # precommit:
   #   Avoid double checks from bot's automated release PR
   #   if: ${{ github.actor != 'github-actions' && github.event_name == 'pull_request' }}
-  #   uses: chime-sps/champss_software/.github/workflows/precommit.yml@main
+  #   uses: ./.github/workflows/precommit.yml
   #   secrets: inherit
   benchmark:
     if: ${{ github.actor != 'github-actions' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') }}
-    uses: chime-sps/champss_software/.github/workflows/benchmark.yml@main
+    uses: ./.github/workflows/benchmark.yml
     secrets: inherit
     with:
       branch_name: ${{ github.head_ref || 'benchmark' }}
   test:
     # Last check makes sure we're not building a test image if pushing to main, as that will already trigger a build in continuous-deployment.yml
     if: ${{ github.actor != 'github-actions' && (contains(github.event.head_commit.message, '[test]') == true) && github.event_name == 'push' && github.ref_name != 'main' }}
-    uses: chime-sps/champss_software/.github/workflows/image.yml@main
+    uses: ./.github/workflows/image.yml
     secrets: inherit
     with:
       runs_on: self-hosted

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,13 +1,22 @@
 name: Example
 
 on:
+  # Trigger this workflow when a commit is pushed to <your_branch_name>
   # push:
   #  branches:
   #    - <your_branch_name>
 
+  # Trigger this workflow when a pull request is opened/updated and targeting the main branch
   # pull_request:
   #   branches:
   #     - main
+
+  # This allows you to run this GitHub Actions Workflow after another specified workflow is completed, based on the Name attribute:
+  # workflow_run:
+  #   workflows:
+  #     - Continuous Integration
+  #   types:
+  #     - completed
 
   # This allows manual dispatch, through the "Actions" tab in your GitHub repository, or through the CLI:
   # gh workflow run .github/workflows/example.yml --ref <your_branch> --field run_job_1=true --field run_job_2=true
@@ -20,15 +29,7 @@ on:
         type: boolean
         default: false
 
-  # This allows use to re-use this GitHub Actions Workflow in other workflows:
-  # name: EXAMPLE
-  # jobs:
-  #   my_job_testing_reuse:
-  #     runs-on: sps-archiver1
-  #     uses: chime-sps/champss-software/.github/workflows/example.yml@main
-  #     with:
-  #       run_job_1: true
-  #       run_job_2: true
+  # This allows you to re-use this GitHub Actions Workflow in other workflows:
   workflow_call:
     inputs:
       run_job_1:
@@ -38,12 +39,16 @@ on:
         type: boolean
         default: false
 
-  # This allows you to run this GitHub Actions Workflow when another specified workflow is completed:
-  # workflow_run:
-  #   workflows:
-  #     - Continuous Integration
-  #   types:
-  #     - completed
+  # name: EXAMPLE
+  # jobs:
+  #   my_job_testing_reuse:
+  #     runs-on: sps-archiver1
+  #     uses: ./.github/workflows/example.yml@main -> if on this repository
+  #     uses: champss_software/.github/workflows/example.yml@main -> if on another repository
+  #     secrets: inherit
+  #     with:
+  #       run_job_1: true
+  #       run_job_2: true
 
 jobs:
   job1:


### PR DESCRIPTION
.. for ease of development branch testing in regards to CI/CD modifications