### PR TITLE
enable saving medians to database

### DIFF
--- a/champss/sps-pipeline/sps_pipeline/sps_config.yml
+++ b/champss/sps-pipeline/sps_pipeline/sps_config.yml
@@ -56,6 +56,9 @@ ps_creation:
   zero_replace: True
   remove_rednoise: True
   nbit: 32
+  save_medians: False
+  write_medians: False
+  write_zero_dm_medians: True
 ps:
   run_ps_search: True
   write_ps_detections: False


### PR DESCRIPTION
This PR saves the file paths created by the write_medians and write_zero_dm_medians to the database and automatically loads them when the Observation is loaded. I turned write_zero_dm_medians on by default for now, since that is very lightweight.

The values for the DM 0 series lightly differ due to RFI cleaning presumable. Not sure if one was favoured other the other. Could also move the DM 0 method to the same spot where the other is saved so it is not reliant on dynamic filter method.

 Also added the option to not load the birdie and rn arrays when loading a dict. Might want to turn that on if the performance cost is too high.

Slightly changed the lines where a new axis was added to the rn arrays to make them simpler. (Personal taste...)