### PR TITLE
Rewrite frequency ranges

### DIFF
--- a/champss/ps-processes/ps_processes/ps_pipeline.py
+++ b/champss/ps-processes/ps_processes/ps_pipeline.py
@@ -192,7 +192,6 @@ class PowerSpectraPipeline:
         injection_path,
         injection_idx,
         only_injections,
-        cutoff_frequency,
         scale_injections=False,
         filepath="./",
         prefix="",
@@ -205,7 +204,6 @@ class PowerSpectraPipeline:
             injection_path,
             injection_idx,
             only_injections,
-            cutoff_frequency,
             scale_injections,
         )
         if self.write_ps_detections and power_spectra_detection_clusters is not None:

--- a/champss/sps-pipeline/sps_pipeline/pipeline.py
+++ b/champss/sps-pipeline/sps_pipeline/pipeline.py
@@ -293,12 +293,6 @@ def dbexcepthook(type, value, tb):
     help="Only process clusters containing injections.",
 )
 @click.option(
-    "--cutoff-frequency",
-    default=100.0,
-    type=float,
-    help="Frequency at which to stop processing candidates.",
-)
-@click.option(
     "--scale-injections/--not-scale-injections",
     default=False,
     help="Scale injection so that input sigma should be detected sigma.",
@@ -341,7 +335,6 @@ def main(
     injection_path,
     injection_idx,
     only_injections,
-    cutoff_frequency,
     scale_injections,
     datpath,
     config_options,
@@ -649,7 +642,6 @@ def main(
                         injection_path,
                         injection_idx,
                         only_injections,
-                        cutoff_frequency,
                         scale_injections,
                         obs_folder,
                         prefix,

--- a/champss/sps-pipeline/sps_pipeline/sps_config.yml
+++ b/champss/sps-pipeline/sps_pipeline/sps_config.yml
@@ -141,7 +141,7 @@ ps:
     precompute_harms: True
     use_nsum_per_bin: True
     skip_first_n_bins: 5
-    max_search_frequency: 500
+    max_search_frequency: 250
     cluster_config:
       dbscan_eps: 1
       dm_scale_factor: 0.02

--- a/champss/sps-pipeline/sps_pipeline/sps_config.yml
+++ b/champss/sps-pipeline/sps_pipeline/sps_config.yml
@@ -141,6 +141,7 @@ ps:
     precompute_harms: True
     use_nsum_per_bin: True
     skip_first_n_bins: 5
+    max_search_frequency: 500
     cluster_config:
       dbscan_eps: 1
       dm_scale_factor: 0.02


### PR DESCRIPTION
I changed the way that our maximum frequency is defined from a command line option to a config option.

We wanted to raise it, right? I am not sure if a detection with very few harmonics will actually allow us to discern it from other detections due to noise, so I set it to 250 for now. What do injections look like in that regime?
I tried a bit so see faster pulsars in our observations, but was not successful before beegfs went down again.

Also two minor changes in the search loop.

The minimum detection frequency is 10 times the frequency of the first bin. (Made it a bit easier for my scheme of processing general data.) This changes things a bit when we go to longer observations with larger spectra.

The search loop now stops at the maximum frequency (very minor performance gain).