### PR TITLE
Beam model public

### DIFF
--- a/champss/beamformer/beamformer/utilities/common.py
+++ b/champss/beamformer/beamformer/utilities/common.py
@@ -14,18 +14,18 @@ from beamformer import CURRENT_POINTING_MAP, NoSuchPointingError
 from sps_common import constants
 from sps_databases import db_utils, models
 
-if importlib.util.find_spec("beam_model"):
-    import beam_model
+if importlib.util.find_spec("cfbm"):
+    import cfbm as beam_model
 
 log = logging.getLogger(__name__)
 
-if "beam_model" in sys.modules:
+if "cfbm" in sys.modules:
     config = beam_model.current_config
     try:
         beammod = beam_model.current_model_class(config)
     except FileNotFoundError:
         log.error("Missing files for beam model. Will try to load them.")
-        from beam_model.bm_data import get_data
+        from cfbm.bm_data import get_data
 
         get_data.main()
         beammod = beam_model.current_model_class(config)
@@ -47,10 +47,10 @@ def find_next_transit(ra: float, dec: float, ref_time: datetime.datetime) -> flo
     Returns:
         float: Transit time in utc in unix format
     """
-    if "beam_model" not in sys.modules:
+    if "cfbm" not in sys.modules:
         sys.exit(
             "ImportError: Using find_next_transit() function requires FRB"
-            " beam_model. Please install beam_model if you plan to use this function."
+            " beam_model. Please install cfbm if you plan to use this function."
         )
     coord = ephem.Equatorial(ephem.degrees(str(ra)), ephem.degrees(str(dec)))
     body = ephem.FixedBody()

--- a/champss/beamformer/beamformer/utilities/msg2fil_beamformed.py
+++ b/champss/beamformer/beamformer/utilities/msg2fil_beamformed.py
@@ -6,13 +6,17 @@ import sys
 import numpy as np
 import pytz
 from astropy.time import Time
-from frb_common import beam_model, common_utils
+import cfbm as beam_model
 from iautils import cascade
 from iautils.conversion import chime_intensity, filterbank
+from sps_common.constants import FREQ_BOTTOM, FREQ_TOP, TSAMP, L1_NCHAN
 
 beammod = beam_model.current_model_class(beam_model.current_config)
 
 SCRUNCH_FACTORS = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+
+# CHIME channel bandwidth
+CHANNEL_BANDWIDTH = (FREQ_TOP - FREQ_BOTTOM) / L1_NCHAN
 
 
 def create_filterbank_header(cas, filename, psr, ra_hms, dec_hms, start_time_mjd):
@@ -232,9 +236,9 @@ def convert_chunk(msg_chunk, beam, dm, fscrunch=1, zerodm=False):
         dm=dm,
         event_time=event_time,
         fpga_time=fpga_time,
-        fbottom=common_utils.freq_bottom_mhz,
-        dt=common_utils.sampling_time_ms / 1e3 * binning,
-        df=common_utils.channel_bandwidth_mhz,
+        fbottom=FREQ_BOTTOM,
+        dt=TSAMP * binning,
+        df=CHANNEL_BANDWIDTH,
     )
 
     # replace missing channels with mean of good channels

--- a/champss/beamformer/pyproject.toml
+++ b/champss/beamformer/pyproject.toml
@@ -22,6 +22,7 @@ prometheus-client = "^0.17.1"
 pytz = "^2023.3"
 scipy = "^1.10.1"
 ephem = "^4.0"
+cfbm = {git = "https://github.com/chime-frb-open-data/chime-frb-beam-model"}
 
 [tool.poetry.group.dev.dependencies]
 commitizen = "^3.4.0"

--- a/champss/beamformer/pyproject.toml
+++ b/champss/beamformer/pyproject.toml
@@ -21,7 +21,7 @@ numpy = "^1.24.3"
 prometheus-client = "^0.17.1"
 pytz = "^2023.3"
 scipy = "^1.10.1"
-ephem = "^4.0"
+ephem = ">=3.7.7.0"
 cfbm = {git = "https://github.com/chime-frb-open-data/chime-frb-beam-model"}
 
 [tool.poetry.group.dev.dependencies]

--- a/champss/rfi-mitigation/pyproject.toml
+++ b/champss/rfi-mitigation/pyproject.toml
@@ -22,6 +22,7 @@ pyfftw = "^0.13.1"
 pyyaml = "^6.0"
 scipy = "^1.10.1"
 tqdm = "^4.66.5"
+cfbm = {git = "https://github.com/chime-frb-open-data/chime-frb-beam-model"}
 
 [tool.poetry.group.dev.dependencies]
 commitizen = "^3.4.0"

--- a/champss/rfi-mitigation/rfi_mitigation/conversion.py
+++ b/champss/rfi-mitigation/rfi_mitigation/conversion.py
@@ -11,8 +11,8 @@ from sps_common.constants import TSAMP
 import numpy as np
 
 # Conditional import for beam_model
-if importlib.util.find_spec("beam_model"):
-    import beam_model
+if importlib.util.find_spec("cfbm"):
+    import cfbm as beam_model
 
 
 def read_huff_msgpack(filename, channel_downsampling_factor=1):
@@ -156,10 +156,10 @@ def convert_intensity_to_filterbank(
     """
 
     # check if beam model is imported
-    if "beam_model" not in sys.modules:
+    if "cfbm" not in sys.modules:
         sys.exit(
             "ImportError: Using convert_intensity_to_filterbank() function requires FRB"
-            " beam_model. Please install beam_model if you plan to use this function."
+            " beam_model. Please install cfbm if you plan to use this function."
         )
 
     nchan = 16384 // channel_downsampling_factor
@@ -194,9 +194,9 @@ def convert_intensity_to_filterbank(
             start_unix_time, end_unix_time, beam
         )
 
-    # Get beam sky position. Postion is computed taking the mid epoch of the exposure.
+    # Get beam sky position. Position is computed taking the mid epoch of the exposure.
     bm = beam_model.current_model_class(beam_model.current_config)
-    beam_pos = bm.get_beam_positions([beam], freqs=bm.clamp_freq)
+    beam_pos = bm.get_beam_positions([beam], freqs=bm.config['clamp_freq'])
     time_mid = (start_unix_time + end_unix_time) / 2
     beam_skypos = SkyCoord(
         *bm.get_equatorial_from_position(beam_pos[0, 0, 0], beam_pos[0, 0, 1], time_mid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,7 @@ sps-databases = {path = "./champss/sps-databases", develop=true}
 sps-dedispersion = {path = "./champss/sps-dedispersion", develop=true}
 sps-multi-pointing = {path = "./champss/multi-pointing", develop=true}
 sps_pipeline = {path = "./champss/sps-pipeline", develop=true}
-beam-model = {git = "ssh://git@github.com/CHIMEFRB/beam-model", optional=true}
-
-[tool.poetry.extras]
-beam-model = ["beam-model"]
+cfbm = {git = "https://github.com/chime-frb-open-data/chime-frb-beam-model"}
 
 [tool.poetry.group.dev.dependencies]
 commitizen = "^3.4.0"


### PR DESCRIPTION
Replaces the private CHIME beam model with the public CHIME beam model repo.  This makes the installation easier, and has identical functionality.

There may be differences down the line for e.g. gain vs position, frequency, but these can be added later (and are not used by us in any way)