### PR TITLE
Refine services

### DIFF
--- a/champss/folding/multiday_search/fold_multiday.py
+++ b/champss/folding/multiday_search/fold_multiday.py
@@ -11,8 +11,8 @@ from scheduler.workflow import schedule_workflow_job
 from sps_databases import db_api, db_utils
 from sps_pipeline.pipeline import default_datpath
 
-def find_all_dates_with_data(ra, dec, basepath, nday=0, start_date=""):
 
+def find_all_dates_with_data(ra, dec, basepath, nday=0, start_date=""):
     filepaths = np.sort(glob(f"{basepath}/*/*/*"))
     pst = PointingStrategist(create_db=False)
 
@@ -146,7 +146,9 @@ def main(
     dm = source.dm
     nchan_tier = int(np.ceil(np.log2(dm // 212.5 + 1)))
     nchan = 1024 * (2**nchan_tier)
-    dates_with_data = find_all_dates_with_data(ra, dec, datpath, nday=nday, start_date=start_date)
+    dates_with_data = find_all_dates_with_data(
+        ra, dec, datpath, nday=nday, start_date=start_date
+    )
     print(f"Folding {len(dates_with_data)} days of data: {dates_with_data}")
     for i, date in enumerate(dates_with_data):
         if use_workflow:
@@ -186,6 +188,7 @@ def main(
                 workflow_function,
                 workflow_params,
                 workflow_tags,
+                cleanup=False,
             )
             if i == 0:
                 # Wait longer after first job so it creates the parfile
@@ -196,14 +199,21 @@ def main(
                 time.sleep(1)
         else:
             args = [
-            "--date", str(date),
-            "--fs_id", str(fs_id),
-            "--foldpath", str(foldpath),
-            "--datpath", str(datpath),
-            "--db-port", str(db_port),
-            "--db-name", str(db_name),
-            "--db-host", str(db_host),
-            "--write-to-db",
+                "--date",
+                str(date),
+                "--fs_id",
+                str(fs_id),
+                "--foldpath",
+                str(foldpath),
+                "--datpath",
+                str(datpath),
+                "--db-port",
+                str(db_port),
+                "--db-name",
+                str(db_name),
+                "--db-host",
+                str(db_host),
+                "--write-to-db",
             ]
             if overwrite_folding:
                 args.append("--overwrite-folding")

--- a/champss/folding/multiday_search/multidayfold_pipeline.py
+++ b/champss/folding/multiday_search/multidayfold_pipeline.py
@@ -203,6 +203,7 @@ def main(
             workflow_function,
             workflow_params,
             workflow_tags,
+            cleanup=False,
         )
 
         wait_for_no_tasks_in_states(

--- a/champss/scheduler/scheduler/workflow.py
+++ b/champss/scheduler/scheduler/workflow.py
@@ -326,6 +326,7 @@ def schedule_workflow_job(
     workflow_user="CHAMPSS",
     timeout=task_timeout_seconds,
     return_service_id=False,
+    cleanup=True,
 ):
     """
     Deposit Work and scale Docker Service, as node resources are free.
@@ -345,6 +346,7 @@ def schedule_workflow_job(
     workflow_user (str): Name of the user who shall own the Workflow job.
     timeout (int): Timeout of the workflow task
     return_service_id (bool): Also return service id and not only work id
+    cleanup (bool): Start cleanup thread. If not used, you may want to use wait_for_no_tasks_in_states
 
     Returns:
     str: The ID of the deposited Workflow job if successful, otherwise an empty string.
@@ -446,10 +448,11 @@ def schedule_workflow_job(
         service = docker_client.services.create(**docker_service)
         service_id = service.attrs["ID"]
         status = wait_until_service_not_pending(service_id)
-        remove_service_thread = threading.Thread(
-            target=remove_finished_service, args=(service_id,)
-        )
-        remove_service_thread.start()
+        if cleanup:
+            remove_service_thread = threading.Thread(
+                target=remove_finished_service, args=(service_id,)
+            )
+            remove_service_thread.start()
         if return_service_id:
             return work_id[0], service_id
         else:

--- a/champss/sps-pipeline/sps_pipeline/processing.py
+++ b/champss/sps-pipeline/sps_pipeline/processing.py
@@ -976,7 +976,7 @@ def run_all_pipeline_processes(
 
     requested_containers = 100
     update_time = 60
-    surplus_replicas = 20
+    surplus_replicas = 10
     # This checks if enough work objects have been deposited. More work objects are scheduled in the background
     for work_index, work in enumerate(work_ids):
         if work_index > requested_containers:

--- a/champss/sps-pipeline/sps_pipeline/processing.py
+++ b/champss/sps-pipeline/sps_pipeline/processing.py
@@ -2168,7 +2168,7 @@ def start_processing_services(
         "restart_policy": docker.types.RestartPolicy(condition="none", max_attempts=0),
         # Labels allow for easy filtering with Docker CLI
         "labels": {"type": "processing"},
-        "constraints": ["node.role == manager"],
+        "constraints": ["node.hostname == sps-archiver1"],
         # Will throw an error if you give two of the same bind mount paths
         # e.g. avoid double-mounting basepath and stackpath when they are the same
         "mounts": [


### PR DESCRIPTION
Currently there are two different processes trying to clean up the fold processes from multiday folding. This prevents the logs from being written sometimes. 

This PR allows turning of the cleanup service in schedule_workflow_job.

It also reduces the number of queued services during normal processing to potentially make it easier to queue other services.