### PR TITLE
Manual candidate creation

### DIFF
--- a/champss/candidate-processor/candidate_processor/feature_generator.py
+++ b/champss/candidate-processor/candidate_processor/feature_generator.py
@@ -590,7 +590,7 @@ class Features:
                             )
                     except Exception as ex:
                         log.exception(
-                            f'{feature_config["feature"]} could not be initialized due'
+                            f"{feature_config['feature']} could not be initialized due"
                             " to the following"
                         )
                         log.exception(ex)
@@ -720,6 +720,7 @@ class Features:
             dm_sigma_1d=dm_sigma_1d_dict,
             sigmas_per_harmonic_sum=sigmas_per_harmonic_sum_dict,
             pspec_freq_resolution=pspec_meta_data.freq_labels[1],
+            manual_candidate=cluster.manual_candidate,
         )
         return SinglePointingCandidate(**spc_init_dict)
 

--- a/champss/multi-pointing/sps_multi_pointing/data_reader.py
+++ b/champss/multi-pointing/sps_multi_pointing/data_reader.py
@@ -59,7 +59,7 @@ def read_cands_summaries(file, sigma_threshold=0):
 
         if len(spcc.candidates):
             datetimes = spcc.candidates[0].datetimes
-            for cand_index, candidate in enumerate(spcc.candidates):
+            for cand_index, candidate in enumerate(spcc.get_real_search_candidates()):
                 if candidate.sigma < sigma_threshold:
                     continue
                 cand_summary = EasyDict(candidate.summary)

--- a/champss/ps-processes/ps_processes/processes/clustering.py
+++ b/champss/ps-processes/ps_processes/processes/clustering.py
@@ -1163,6 +1163,7 @@ class Clusterer:
                     nharm=cluster.nharm,
                     harm_idx=cluster.harm_idx,
                     injection=cluster.injection_index,
+                    manual_candidate="",
                 )
                 current_label += 1
         if zero_dm_count:

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -562,6 +562,19 @@ class PowerSpectraSearch:
                                     source.dm,
                                 ]
                             )
+                elif split_manual_cand[0] == "nearby_fs":
+                    followup_sources = db_api.get_nearby_followup_sources(
+                        pspec.ra, pspec.dec, radius=float(split_manual_cand[1])
+                    )
+                    for source in followup_sources:
+                        if np.isfinite(source.f0) and np.isfinite(source.dm):
+                            used_manual_candidates.append(
+                                [
+                                    source.source_name,
+                                    source.f0,
+                                    source.dm,
+                                ]
+                            )
                 elif split_manual_cand[0] == "PSR":
                     source = db_api.get_known_source_by_names(split_manual_cand[1])
                     if len(source):

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -541,8 +541,8 @@ class PowerSpectraSearch:
             current_label = 0
         else:
             current_label = max(all_cluster_labels) + 1
+        used_manual_candidates = []
         if manual_candidates:
-            used_manual_candidates = []
             for manual_cand in manual_candidates:
                 split_manual_cand = manual_cand.split(" ")
                 if split_manual_cand[0] == "para":

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -27,6 +27,7 @@ from sps_common.interfaces.utilities import (
 )
 from sps_common.constants import TSAMP
 from sps_databases import db_api
+from sps_common.interfaces import Cluster
 
 log = logging.getLogger(__name__)
 
@@ -178,6 +179,7 @@ class PowerSpectraSearch:
         injection_indices=[],
         only_injections=False,
         scale_injections=False,
+        manual_candidates=[],
     ):
         """
         Run the search.
@@ -394,36 +396,6 @@ class PowerSpectraSearch:
             )
             self.full_harm_bins[dummy_harmonics != 0] = 0
 
-        # Calculate the used number of each days in each pixel for each harmonic sum
-        # From that calculate the power_cutoff.
-        # Calculating for each DM trial would be slower.
-        # The harmonics are also currently hard-coded in the search routine currently
-        all_harmonic_vals = np.array([1, 2, 4, 8, 16, 32])
-        if self.use_nsum_per_bin:
-            power_cutoff_per_harmonic = np.zeros(
-                (6, self.padded_length // 2), dtype=float
-            )
-            nsum_per_harmonic = np.zeros((6, self.padded_length // 2), dtype=int)
-            num_days_per_bin = pspec.get_bin_weights()
-            # For masked bins make sure that 0th bins is 0
-            num_days_per_bin[0] = 0
-            if len(filtered_sources):
-                num_days_per_bin[bad_freq_indices] = 0
-            for idx_harm, harm in enumerate(all_harmonic_vals):
-                nsum_harm_bins = self.full_harm_bins[:harm]
-                nsum_current_harmonic = num_days_per_bin[nsum_harm_bins].sum(0)
-                nsum_per_harmonic[idx_harm, :] = nsum_current_harmonic
-                power_cutoff_per_harmonic[idx_harm, :] = powersum_at_sigma(
-                    self.sigma_min, nsum_current_harmonic
-                )
-                power_cutoff_per_harmonic[idx_harm, nsum_current_harmonic == 0] = np.inf
-        else:
-            nsum_per_harmonic = all_harmonic_vals * pspec.num_days
-            power_cutoff_per_harmonic = powersum_at_sigma(
-                self.sigma_min, nsum_per_harmonic
-            )
-
-        pool = Pool(self.num_threads)
         detection_dtype = [
             ("freq", float),
             ("dm", float),
@@ -444,84 +416,203 @@ class PowerSpectraSearch:
             ),
             ("sigma", float),
             ("injection", int),
+            ("manual_candidate", "30U"),  # For now string with length 30
         ]
-        # multiprocessing pool to run the search as a parallel process.
-        log.info(
-            f"Start searching {len(pspec.dms)} dm trials using"
-            f" {self.num_harm} harmonics."
-        )
-        # Move spectra to shared memory if they are not already.
-        # Alternatively the search_candidates function could be rewritten
-        # to work with shared and non-shared memory
-        pspec.move_to_shared_memory()
-        if not self.mp_chunk_size:
-            self.mp_chunk_size = len(pspec.dms) // self.num_threads + 1
-        log.info(
-            f"Number of dm trials in single multi processing job: {self.mp_chunk_size}"
-        )
+        if "skip_search" not in manual_candidates:
+            # Calculate the used number of each days in each pixel for each harmonic sum
+            # From that calculate the power_cutoff.
+            # Calculating for each DM trial would be slower.
+            # The harmonics are also currently hard-coded in the search routine currently
+            all_harmonic_vals = np.array([1, 2, 4, 8, 16, 32])
+            if self.use_nsum_per_bin:
+                power_cutoff_per_harmonic = np.zeros(
+                    (6, self.padded_length // 2), dtype=float
+                )
+                nsum_per_harmonic = np.zeros((6, self.padded_length // 2), dtype=int)
+                num_days_per_bin = pspec.get_bin_weights()
+                # For masked bins make sure that 0th bins is 0
+                num_days_per_bin[0] = 0
+                if len(filtered_sources):
+                    num_days_per_bin[bad_freq_indices] = 0
+                for idx_harm, harm in enumerate(all_harmonic_vals):
+                    nsum_harm_bins = self.full_harm_bins[:harm]
+                    nsum_current_harmonic = num_days_per_bin[nsum_harm_bins].sum(0)
+                    nsum_per_harmonic[idx_harm, :] = nsum_current_harmonic
+                    power_cutoff_per_harmonic[idx_harm, :] = powersum_at_sigma(
+                        self.sigma_min, nsum_current_harmonic
+                    )
+                    power_cutoff_per_harmonic[idx_harm, nsum_current_harmonic == 0] = (
+                        np.inf
+                    )
+            else:
+                nsum_per_harmonic = all_harmonic_vals * pspec.num_days
+                power_cutoff_per_harmonic = powersum_at_sigma(
+                    self.sigma_min, nsum_per_harmonic
+                )
 
-        dm_split = [
-            pspec.dms[i : i + self.mp_chunk_size]
-            for i in range(0, len(pspec.dms), self.mp_chunk_size)
-        ]
-        full_indices = np.arange(len(pspec.dms))
-        dm_indices = [
-            full_indices[i : i + self.mp_chunk_size]
-            for i in range(0, len(pspec.dms), self.mp_chunk_size)
-        ]
-        detection_list = pool.starmap(
-            partial(
-                self.search_candidates,
-                pspec.power_spectra_shared.name,
-                pspec.power_spectra.shape,
-                pspec.power_spectra.dtype,
-                self.num_harm,
-                self.full_harm_bins,
-                pspec.freq_labels,
-                nsum_per_harmonic,
-                power_cutoff_per_harmonic,
-                injection_dicts,
-                self.max_search_frequency,
-                self.skip_first_n_bins,
-                self.injection_overlap_threshold,
-                self.injection_dm_threshold,
-            ),
-            zip(dm_indices, dm_split),
-        )
-        pool.close()
-        pool.join()
+            pool = Pool(self.num_threads)
+            # multiprocessing pool to run the search as a parallel process.
+            log.info(
+                f"Start searching {len(pspec.dms)} dm trials using"
+                f" {self.num_harm} harmonics."
+            )
+            # Move spectra to shared memory if they are not already.
+            # Alternatively the search_candidates function could be rewritten
+            # to work with shared and non-shared memory
+            pspec.move_to_shared_memory()
+            if not self.mp_chunk_size:
+                self.mp_chunk_size = len(pspec.dms) // self.num_threads + 1
+            log.info(
+                f"Number of dm trials in single multi processing job: {self.mp_chunk_size}"
+            )
 
-        search_end = time.time()
-        log.debug(f"Took {search_end - search_start} seconds to run search")
+            dm_split = [
+                pspec.dms[i : i + self.mp_chunk_size]
+                for i in range(0, len(pspec.dms), self.mp_chunk_size)
+            ]
+            full_indices = np.arange(len(pspec.dms))
+            dm_indices = [
+                full_indices[i : i + self.mp_chunk_size]
+                for i in range(0, len(pspec.dms), self.mp_chunk_size)
+            ]
+            detection_list = pool.starmap(
+                partial(
+                    self.search_candidates,
+                    pspec.power_spectra_shared.name,
+                    pspec.power_spectra.shape,
+                    pspec.power_spectra.dtype,
+                    self.num_harm,
+                    self.full_harm_bins,
+                    pspec.freq_labels,
+                    nsum_per_harmonic,
+                    power_cutoff_per_harmonic,
+                    injection_dicts,
+                    self.max_search_frequency,
+                    self.skip_first_n_bins,
+                    self.injection_overlap_threshold,
+                    self.injection_dm_threshold,
+                ),
+                zip(dm_indices, dm_split),
+            )
+            pool.close()
+            pool.join()
 
-        # convert the full detection list into a numpy structured array
-        detections = np.array(
-            [j for sub in detection_list for j in sub], dtype=detection_dtype
-        )
-        log.info(f"Total number of detections={len(detections)}")
-        # if len(detections) == 0:
-        #     log.warning("No detections made. Further processing will not be completed.")
-        #     return None
-        log.info("Clustering the detections")
-        clusterer = Clusterer(
-            **self.cluster_config,
-            sigma_detection_threshold=self.sigma_min,
-            num_threads=self.num_threads,
-        )
-        cluster_dm_spacing = pspec.dms[1] - pspec.dms[0]
-        cluster_df_spacing = pspec.freq_labels[1]
-        (
-            clusters,
-            summary,
-            clustering_sigma_min,
-            used_detections_len,
-        ) = clusterer.make_clusters(
-            detections,
-            cluster_dm_spacing,
-            cluster_df_spacing,
-            plot_fname="",
-            only_injections=only_injections,
-        )
+            search_end = time.time()
+            log.debug(f"Took {search_end - search_start} seconds to run search")
+
+            # convert the full detection list into a numpy structured array
+            detections = np.array(
+                [j for sub in detection_list for j in sub], dtype=detection_dtype
+            )
+            log.info(f"Total number of detections={len(detections)}")
+            # if len(detections) == 0:
+            #     log.warning("No detections made. Further processing will not be completed.")
+            #     return None
+            log.info("Clustering the detections")
+            clusterer = Clusterer(
+                **self.cluster_config,
+                sigma_detection_threshold=self.sigma_min,
+                num_threads=self.num_threads,
+            )
+            cluster_dm_spacing = pspec.dms[1] - pspec.dms[0]
+            cluster_df_spacing = pspec.freq_labels[1]
+            (
+                clusters,
+                summary,
+                clustering_sigma_min,
+                used_detections_len,
+            ) = clusterer.make_clusters(
+                detections,
+                cluster_dm_spacing,
+                cluster_df_spacing,
+                plot_fname="",
+                only_injections=only_injections,
+            )
+        else:
+            clusters = {}
+            summary = {}
+            clustering_sigma_min = self.sigma_min
+            used_detections_len = 0
+            detections = np.array([], dtype=detection_dtype)
+            cluster_df_spacing = pspec.freq_labels[1]
+
+        all_cluster_labels = [int(label) for label in clusters.keys()]
+        if len(all_cluster_labels) == 0:
+            current_label = 0
+        else:
+            current_label = max(all_cluster_labels) + 1
+        if manual_candidates:
+            used_manual_candidates = []
+            for manual_cand in manual_candidates:
+                split_manual_cand = manual_cand.split(" ")
+                if split_manual_cand[0] == "para":
+                    freq = float(split_manual_cand[1])
+                    dm = float(split_manual_cand[2])
+                    used_manual_candidates.append([manual_cand, freq, dm])
+                elif split_manual_cand[0] == "nearby_ks":
+                    known_sources = db_api.get_nearby_known_sources(
+                        pspec.ra, pspec.dec, radius=float(split_manual_cand[1])
+                    )
+                    for source in known_sources:
+                        if np.isfinite(source.spin_period_s) and np.isfinite(source.dm):
+                            used_manual_candidates.append(
+                                [
+                                    source.source_name,
+                                    1 / source.spin_period_s,
+                                    source.dm,
+                                ]
+                            )
+                elif split_manual_cand[0] == "PSR":
+                    source = db_api.get_known_source_by_names(split_manual_cand[1])
+                    if len(source):
+                        source = source[0]
+                        used_manual_candidates.append(
+                            [source.source_name, 1 / source.spin_period_s, source.dm]
+                        )
+                    else:
+                        log.error(f"Source {split_manual_cand[1]} not found in db.")
+                elif split_manual_cand[0] == "FS":
+                    fs = db_api.get_followup_source(split_manual_cand[1])
+                    used_manual_candidates.append([fs.source_name, fs.f0, fs.dm])
+                elif split_manual_cand[0] == "injection":
+                    for injection_index, injection_dict in enumerate(injection_dicts):
+                        used_manual_candidates.append(
+                            [
+                                f"Injection_{injection_index}",
+                                injection_dict["frequency"],
+                                injection_dict["DM"],
+                            ]
+                        )
+                elif split_manual_cand[0] == "skip_search":
+                    continue
+                else:
+                    log.error(
+                        f"Could not create manual candidate for {manual_cand}. Unknown format."
+                    )
+            log.info(
+                f"Will create the following manual candidates: {used_manual_candidates}"
+            )
+        for manual_cand in used_manual_candidates:
+            man_cand_detections = self.get_detections_from_manual_cand(
+                pspec, manual_cand[1], manual_cand[2], manual_cand[0]
+            )
+            man_cand_detections_array = np.array(
+                man_cand_detections, dtype=detection_dtype
+            )
+            man_cand_cluster = Cluster.from_raw_detections(man_cand_detections_array)
+            clusters[current_label] = man_cand_cluster
+            summary[current_label] = dict(
+                freq=man_cand_cluster.freq,
+                dm=man_cand_cluster.dm,
+                sigma=man_cand_cluster.sigma,
+                nharm=man_cand_cluster.nharm,
+                harm_idx=man_cand_cluster.harm_idx,
+                injection=man_cand_cluster.injection_index,
+                manual_candidate=manual_cand[0],
+            )
+            current_label += 1
+            detections = np.append(detections, man_cand_detections_array)
+
         # if len(clusters) == 0:
         #     log.warning("No clusters found. Further processing will not be completed.")
         #     return None
@@ -665,7 +756,7 @@ class PowerSpectraSearch:
                     continue
                 last_detection_freq = None
                 last_detection_sigma = None
-                if type(used_nsum) == np.ndarray:
+                if type(used_nsum) is np.ndarray:
                     used_nsum_detec = used_nsum[detection_idx]
                 else:
                     used_nsum_detec = used_nsum
@@ -683,7 +774,7 @@ class PowerSpectraSearch:
                         break
 
                     if sigmas is None:
-                        if type(used_nsum) == np.ndarray:
+                        if type(used_nsum) is np.ndarray:
                             used_nsum_detec_loop = used_nsum[idx]
                         else:
                             used_nsum_detec_loop = used_nsum
@@ -693,7 +784,7 @@ class PowerSpectraSearch:
                     else:
                         sigma = sigmas[idx_count]
                         if np.isnan(sigma):
-                            if type(used_nsum) == np.ndarray:
+                            if type(used_nsum) is np.ndarray:
                                 used_nsum_detec_loop = used_nsum[idx]
                             else:
                                 used_nsum_detec_loop = used_nsum
@@ -748,6 +839,7 @@ class PowerSpectraSearch:
                             ),
                             sigma,
                             injected_index,
+                            "",
                         )
                     else:
                         detection_list.append(
@@ -769,6 +861,7 @@ class PowerSpectraSearch:
                                 ),
                                 sigma,
                                 injected_index,
+                                "",
                             )
                         )
                     last_detection_freq = detection_freq
@@ -819,3 +912,38 @@ class PowerSpectraSearch:
             else:
                 summary[c]["rfi"] = False
         return summary
+
+    def get_detections_from_manual_cand(self, pspec, freq, dm, cand_description):
+        all_harmonic_vals = np.array([1, 2, 4, 8, 16, 32])
+        detections = []
+        dm_index = np.argmin(np.abs(pspec.dms - dm))
+        if "Injection" in cand_description:
+            injection_index = int(cand_description.split("_")[-1])
+        else:
+            injection_index = -1
+        for harmonic in all_harmonic_vals:
+            current_freq_labels = pspec.freq_labels / harmonic
+            freq_index = np.argmin(np.abs(current_freq_labels - freq))
+            sorted_harm_bins = sorted(
+                self.full_harm_bins[:harmonic, freq_index].astype(int)
+            )
+            powers = pspec.power_spectra[dm_index, sorted_harm_bins]
+            powers_sum = powers.sum()
+            sigma = sigma_sum_powers(powers_sum, harmonic * pspec.num_days)
+            detection = (
+                freq,
+                dm,
+                1,
+                tuple(np.pad(sorted_harm_bins, (0, 32 - len(sorted_harm_bins)))),
+                tuple(
+                    np.pad(
+                        powers,
+                        (0, 32 - len(powers)),
+                    )
+                ),
+                sigma,
+                injection_index,
+                cand_description,
+            )
+            detections.append(detection)
+        return detections

--- a/champss/ps-processes/ps_processes/ps_pipeline.py
+++ b/champss/ps-processes/ps_processes/ps_pipeline.py
@@ -195,6 +195,7 @@ class PowerSpectraPipeline:
         scale_injections=False,
         filepath="./",
         prefix="",
+        manual_candidates=[],
     ):
         (
             power_spectra_detection_clusters,
@@ -205,6 +206,7 @@ class PowerSpectraPipeline:
             injection_idx,
             only_injections,
             scale_injections,
+            manual_candidates=manual_candidates,
         )
         if self.write_ps_detections and power_spectra_detection_clusters is not None:
             filename = f"{prefix}_power_spectra_detection_clusters.hdf5"

--- a/champss/sps-common/sps_common/interfaces/default_mp_plot.yml
+++ b/champss/sps-common/sps_common/interfaces/default_mp_plot.yml
@@ -45,6 +45,7 @@ panels:
   - 
   - injection
   - injection_dict
+  - manual_candidate
 - col_range:
   - 0
   - 2

--- a/champss/sps-common/sps_common/interfaces/default_sp_plot.yml
+++ b/champss/sps-common/sps_common/interfaces/default_sp_plot.yml
@@ -43,6 +43,7 @@ panels:
   - 
   - injection
   - injection_dict
+  - manual_candidate
 - col_range:
   - 0
   - 2

--- a/champss/sps-common/sps_common/interfaces/ps_processes.py
+++ b/champss/sps-common/sps_common/interfaces/ps_processes.py
@@ -240,10 +240,10 @@ class PowerSpectra:
 
     @datetimes.validator
     def _validate_datetimes(self, attribute, value):
-        if type(value) != list:
+        if type(value) is not list:
             raise AttributeError(f"The data type of {attribute.name} is not list.")
         for val in value:
-            if type(val) != datetime:
+            if type(val) is not datetime:
                 raise AttributeError(
                     f"The elements of {attribute.name} are not datetime."
                 )
@@ -483,7 +483,8 @@ class PowerSpectra:
 
             if self.rn_medians is not None:
                 h5f.create_dataset(
-                    "rn medians", data=self.rn_medians, 
+                    "rn medians",
+                    data=self.rn_medians,
                 )
                 h5f.create_dataset("rn scales", data=self.rn_scales)
                 h5f.create_dataset("rn dm indices", data=self.rn_dm_indices)
@@ -744,6 +745,7 @@ class Cluster:
     nharm: int = attrib()
     harm_idx: np.ndarray = attrib()
     injection_index: float = attrib()
+    manual_candidate: str = attrib()
 
     @classmethod
     def from_raw_detections(cls, detections):
@@ -757,6 +759,7 @@ class Cluster:
             harm_idx=max_sig_det["harm_idx"],
             injection_index=max_sig_det["injection"],
             detections=detections,
+            manual_candidate=max_sig_det["manual_candidate"],
         )
         return cls(**init_dict)
 
@@ -881,6 +884,16 @@ class PowerSpectraDetectionClusters:
                 {"freq", "dm", "nharm", "harm_idx", "sigma"},
                 {"freq", "dm", "nharm", "harm_idx", "harm_pow", "sigma"},
                 {"freq", "dm", "nharm", "harm_idx", "harm_pow", "injection", "sigma"},
+                {
+                    "freq",
+                    "dm",
+                    "nharm",
+                    "harm_idx",
+                    "harm_pow",
+                    "injection",
+                    "sigma",
+                    "manual_candidate",
+                },
             ]
             if val_dtype not in acceptable_dtype_names:
                 raise TypeError(

--- a/champss/sps-common/sps_common/interfaces/single_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/single_pointing.py
@@ -180,6 +180,7 @@ class SinglePointingCandidate:
         ),
         default=[],
     )
+    manual_candidate = attrib(type=str, default="")
     # Note `ra`, `dec`, `obs_id` and `detection_statistic` are populated from
     # `SinglePointingCandidateCollection`.
     # they are attributes here too because multi-pointing then uses the
@@ -201,10 +202,10 @@ class SinglePointingCandidate:
     #             f"[{MIN_SEARCH_DM}, {MAX_SEARCH_DM}] pc/cc"
     #         )
 
-    @sigma.validator
-    def _check_sigma(self, attribute, value):
-        if value <= 0:
-            raise ValueError(f"Sigma ({attribute.name}={value}) must be greater than 0")
+    # @sigma.validator
+    # def _check_sigma(self, attribute, value):
+    #     if value <= 0:
+    #         raise ValueError(f"Sigma ({attribute.name}={value}) must be greater than 0")
 
     @ra.validator
     def _check_ra(self, attribute, value):
@@ -573,7 +574,7 @@ class SinglePointingCandidateCollection:
             plots = []
             for candidate in self.candidates:
                 if candidate.sigma > sigma_threshold:
-                    if candidate.dm > dm_threshold:
+                    if candidate.dm > dm_threshold or candidate.manual_candidate != "":
                         plot = candidate.plot_candidate(folder=folder, config=config)
                         plots.append(plot)
         else:
@@ -583,6 +584,7 @@ class SinglePointingCandidateCollection:
                     cand.plot_candidate
                     for cand in self.candidates
                     if ((cand.sigma > sigma_threshold) and (cand.dm > dm_threshold))
+                    or (cand.manual_candidate != "")
                 ]
                 arguments = (folder, config)
                 tasks = zip(functions, repeat(arguments))

--- a/champss/sps-common/sps_common/interfaces/single_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/single_pointing.py
@@ -202,11 +202,6 @@ class SinglePointingCandidate:
     #             f"[{MIN_SEARCH_DM}, {MAX_SEARCH_DM}] pc/cc"
     #         )
 
-    # @sigma.validator
-    # def _check_sigma(self, attribute, value):
-    #     if value <= 0:
-    #         raise ValueError(f"Sigma ({attribute.name}={value}) must be greater than 0")
-
     @ra.validator
     def _check_ra(self, attribute, value):
         if not 0 <= value < 360.0:

--- a/champss/sps-common/sps_common/interfaces/single_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/single_pointing.py
@@ -455,7 +455,8 @@ class SinglePointingCandidateCollection:
     injections (List(dict)): List describing the injections that were performed
                             beffore the search
     injection_indices (List(int)): Indices of the candidates that were injected
-    real_indices (List(int)): Indices of the candidates that were  not injected
+    real_indices (List(int)): Indices of the candidates resulting from the search
+    manual_indices (List(int)): Indices of the manually created candidates
     """
 
     candidates = attrib(
@@ -464,17 +465,17 @@ class SinglePointingCandidateCollection:
             iterable_validator=instance_of(list),
         )
     )
-    real_indices = attrib(
+    injection_flags = attrib(
         init=False,
         validator=deep_iterable(
-            member_validator=instance_of(int),
+            member_validator=instance_of(bool),
             iterable_validator=instance_of(list),
         ),
     )
-    injection_indices = attrib(
+    manual_flags = attrib(
         init=False,
         validator=deep_iterable(
-            member_validator=instance_of(int),
+            member_validator=instance_of(bool),
             iterable_validator=instance_of(list),
         ),
     )
@@ -488,12 +489,12 @@ class SinglePointingCandidateCollection:
 
     def __attrs_post_init__(self):
         """Find indices of real detections and injections."""
-        all_indices = np.arange(len(self.candidates))
-        injection_flags = np.asarray(
+        self.injection_flags = np.asarray(
             [cand.injection for cand in self.candidates], dtype=bool
         )
-        self.real_indices = all_indices[~injection_flags]
-        self.injection_indices = all_indices[injection_flags]
+        self.manual_flags = np.asarray(
+            [(cand.manual_candidate != "") for cand in self.candidates], dtype=bool
+        )
 
     @classmethod
     def read(cls, filename, verbose=True):
@@ -600,11 +601,27 @@ class SinglePointingCandidateCollection:
     def get_real_candidates(self):
         """Get candidates which have not been injected."""
         # Converting to array for easier slicing, could also change the attribute itself to array
-        return np.asarray(self.candidates)[self.real_indices]
+        return np.asarray(self.candidates)[~self.injection_flags]
+
+    def get_real_search_candidates(self):
+        """Get search candidates which have not been injected."""
+        return np.asarray(self.candidates)[~self.injection_flags & ~self.manual_flags]
 
     def get_injection_candidates(self):
         """Get candidates which have been injected."""
-        return np.asarray(self.candidates)[self.injection_indices]
+        return np.asarray(self.candidates)[self.injection_flags]
+
+    def get_search_injection_candidates(self):
+        """Get search candidates which have been injected."""
+        return np.asarray(self.candidates)[self.injection_flags & ~self.manual_flags]
+
+    def get_manual_injection_candidates(self):
+        """Get manual candidates which have been injected."""
+        return np.asarray(self.candidates)[self.injection_flags & self.manual_flags]
+
+    def get_manual_candidates(self):
+        """Get all manual candidate."""
+        return np.asarray(self.candidates)[self.manual_flags]
 
     def test_injection_performance(self, verbose=True):
         """Return dict containing details fo the injection performance."""

--- a/champss/sps-databases/sps_databases/db_api.py
+++ b/champss/sps-databases/sps_databases/db_api.py
@@ -1,6 +1,8 @@
 """Simpe API to gather collection data using pymongo."""
 
 import datetime as dt
+from astropy import units as u
+from astropy.coordinates import angular_separation
 
 import pymongo
 import pytz
@@ -718,9 +720,6 @@ def get_nearby_known_sources(ra, dec, radius=5.0):
     """
     db = db_utils.connect()
 
-    from astropy import units as u
-    from astropy.coordinates import angular_separation
-
     return [
         KnownSource.from_db(source)
         for source in db.known_sources.find()
@@ -920,6 +919,44 @@ def delete_followup_source(fs_id):
     if isinstance(fs_id, str):
         fs_id = ObjectId(fs_id)
     return db.followup_sources.find_one_and_delete({"_id": fs_id})
+
+
+def get_nearby_followup_sources(ra, dec, radius=1.0):
+    """
+    Gets all followup sources from the database near the given (ra, dec) position.
+
+    To find all sources, set radius to infinity.
+
+    Parameters
+    ----------
+    ra, dec: float
+        The Right Ascension and Declination, in degrees, of the sky position
+        around which to search for followup sources.
+
+    radius: float
+        The radius, in degrees, within which all known sources will be
+        returned.
+
+    Returns
+    -------
+    known_sources: list of KnownSource
+        The known sources in the database within the desired distance.
+    """
+    db = db_utils.connect()
+
+    return [
+        FollowUpSource.from_db(source)
+        for source in db.followup_sources.find()
+        if angular_separation(
+            ra * u.degree,
+            dec * u.degree,
+            source["ra"] * u.degree,
+            source["dec"] * u.degree,
+        )
+        .to(u.degree)
+        .value
+        < radius
+    ]
 
 
 def create_process(payload, assume_new=False):

--- a/champss/sps-pipeline/sps_pipeline/pipeline.py
+++ b/champss/sps-pipeline/sps_pipeline/pipeline.py
@@ -286,7 +286,17 @@ def dbexcepthook(type, value, tb):
     default=[],
     type=str,
     multiple=True,
-    help="Allow retrieval of manual candidates. Use skip_search to skip the search and only sue manual candidates.",
+    help=(
+        "Allow retrieval of manual candidates. "
+        "Modes:"
+        "'--mc skip_search': Skip normal search; "
+        "'--mc para freq dm': Create candidate at freq and dm; "
+        "'--mc PSR psr_name': Create candidate at known source psr_name; "
+        "'--mc FS fs_id': Create candidate for followup source at given fs_id; "
+        "'--mc nearby_ks 1': Create candidate for all sources within given radius; "
+        "'--mc nearby_fs 1': Create candidate for followup sources within given radius; "
+        "'--mc injections': Create candidates for all injections; "
+    ),
 )
 def main(
     date,

--- a/champss/sps-pipeline/sps_pipeline/pipeline.py
+++ b/champss/sps-pipeline/sps_pipeline/pipeline.py
@@ -280,6 +280,14 @@ def dbexcepthook(type, value, tb):
         """For example use --config-options '{"beamform": {"max_mask_frac": 0.1}}' """
     ),
 )
+@click.option(
+    "--manual-candidates",
+    "--mc",
+    default=[],
+    type=str,
+    multiple=True,
+    help="Allow retrieval of manual candidates. Use skip_search to skip the search and only sue manual candidates.",
+)
 def main(
     date,
     stack,
@@ -306,6 +314,7 @@ def main(
     scale_injections,
     datpath,
     config_options,
+    manual_candidates,
 ):
     """
     Runner script for the Slow Pulsar Search prototype pipeline v0.
@@ -625,6 +634,7 @@ def main(
                         scale_injections,
                         obs_folder,
                         prefix,
+                        manual_candidates=manual_candidates,
                     )
                     if ps_detections is None:
                         power_spectra.unlink_shared_memory()


### PR DESCRIPTION
This PR allows manual candidate creation from injections, known sources, followup sources and freq-dm pairs.
All option are described in the readme.

This is for now only implimented for the single day search but if there are no futher comments on the general setup I can also look into enabling it for stacks.