### PR TITLE
Add interstellar scattering to ps_inject

### DIFF
--- a/champss/ps-processes/ps_processes/processes/ps_inject.py
+++ b/champss/ps-processes/ps_processes/processes/ps_inject.py
@@ -343,6 +343,65 @@ class Injection:
 
         return prof_fft, phases
 
+    def scattering(self, prof_fft, n_harm, alpha=-4.4, beta=-1.0,
+                   nuref=600.0, tauref=0.01, tsamp=TSAMP*1000, nbin=None):
+        """
+        This function applies scattering to a pulse profile by computing
+        a frequency-summed scattering kernel and multiplying it with the
+        profile harmonics in the Fourier domain. This code was written by Hudson Bridgwater.
+
+        Inputs:
+        -------
+                prof_fft (arr)   : FFT of the pulse profile, excluding the zeroth harmonic,
+                                   with length n_harm
+                n_harm   (int)   : number of harmonics
+                tauref   (float) : scattering timescale at nuref in milliseconds. Default: 0.01
+                alpha    (float) : power-law spectral index of the scattering timescale (freq scaling).
+                                   Default: 0.0
+                beta     (float) : spectral weighting index for frequency averaging.
+                                   Default: 0.0
+                nuref    (float) : reference frequency in MHz. Default: 600.0
+                tsamp    (float) : sampling time in milliseconds. Default: TSAMP * 1000
+                nbin     (int)   : number of phase bins in the profile. If None, uses
+                                   len(self.phase_prof). Default: None
+
+        Returns:
+        --------
+                prof_fft (arr)   : scattered FFT of the pulse profile, with length n_harm
+        """
+        if nbin is None:
+            nbin = len(self.phase_prof)
+        if tauref == 0.0:
+            return prof_fft
+
+        # CHIME constants
+        bandmin = 400.0
+        bandmax = 800.0
+        nchan = 16384
+
+        # Time based kernel
+        dnu = (bandmax - bandmin) / nchan
+        bstart = bandmin + dnu / 2.0
+        bend = bandmax - dnu / 2.0
+        obsfreq = np.linspace(bstart, bend, nchan)
+        t0 = np.arange(nbin) * tsamp
+        nu = obsfreq[:, None]
+        t = t0[None, :]
+
+        tau_ms = tauref * (nu / nuref) ** (alpha)
+        k_i = (1.0 / tau_ms) * np.exp(-t / tau_ms)
+        w_i = (nu / nuref) ** (beta)
+        scatt = k_i * w_i
+        k_eff = np.sum(scatt, axis=0) / np.sum(w_i, axis=0)
+        k_eff /= np.sum(k_eff)
+
+        # Transform kernel to Fourier harmonics
+        K = rfft(k_eff, n=nbin)
+        K_harm = K[1 : n_harm + 1]
+        prof_fft *= K_harm
+
+        return prof_fft
+
     def time_windowing(self, prof_fft):
         # apply Van der Klis Eq 2.19 for time-bin windowing effect
         harmonic_freqs = np.arange(1, len(prof_fft) + 1) * self.f
@@ -591,7 +650,8 @@ class Injection:
         else:
             n_harm = len(scaled_prof_fft)
 
-        windowed_prof_fft = self.time_windowing(scaled_prof_fft)
+        scattered_prof_fft = self.scattering(scaled_prof_fft, n_harm=n_harm)
+        windowed_prof_fft = self.time_windowing(scattered_prof_fft)
         smeared_prof_fft = self.smear_fft(windowed_prof_fft)
 
         log.info(f"Injecting {n_harm} harmonics.")

--- a/champss/ps-processes/ps_processes/processes/ps_inject.py
+++ b/champss/ps-processes/ps_processes/processes/ps_inject.py
@@ -351,7 +351,6 @@ class Injection:
 
         return prof_fft, phases
 
-# --
     def scattering(self, prof_fft, n_harm, alpha=-4.4, beta=-1.6,
                    nuref=600.0, tauref=0.01, nbin=None):
         """
@@ -370,7 +369,8 @@ class Injection:
                                    Default: -4.4
                 beta     (float) : spectral weighting index for frequency averaging.
                                    Default: -1.6
-                nuref    (float) : reference frequency in MHz. Default: 600.0
+                nuref    (float) : reference frequency in MHz.
+                                   Default: 600.0
                 nbin     (int)   : number of phase bins in the profile. If None, uses
                                    len(self.phase_prof). Default: None
 

--- a/champss/ps-processes/ps_processes/processes/ps_inject.py
+++ b/champss/ps-processes/ps_processes/processes/ps_inject.py
@@ -157,6 +157,10 @@ class Injection:
         flux=None,
         sigma=None,
         TPA_idx=None,
+        tauref=0.0,
+        alpha=0.0,
+        beta=0.0,
+        nuref=600.0,
     ):
         self.pspec = pspec_obj.power_spectra
         self.ndays = pspec_obj.num_days
@@ -178,6 +182,10 @@ class Injection:
         self.full_harm_bins = full_harm_bins
         self.rescale_to_expected_sigma = scale_injections
         self.use_rfi_information = True
+        self.tauref = tauref
+        self.alpha = alpha
+        self.beta = beta
+        self.nuref = nuref
         self.W = self.get_fwhm()
         self.Tsky = self.get_tsky()
         if flux is not None:
@@ -343,8 +351,9 @@ class Injection:
 
         return prof_fft, phases
 
-    def scattering(self, prof_fft, n_harm, alpha=-4.4, beta=-1.0,
-                   nuref=600.0, tauref=0.01, tsamp=TSAMP*1000, nbin=None):
+# --
+    def scattering(self, prof_fft, n_harm, alpha=-4.4, beta=-1.6,
+                   nuref=600.0, tauref=0.01, nbin=None):
         """
         This function applies scattering to a pulse profile by computing
         a frequency-summed scattering kernel and multiplying it with the
@@ -355,13 +364,13 @@ class Injection:
                 prof_fft (arr)   : FFT of the pulse profile, excluding the zeroth harmonic,
                                    with length n_harm
                 n_harm   (int)   : number of harmonics
-                tauref   (float) : scattering timescale at nuref in milliseconds. Default: 0.01
+                tauref   (float) : scattering timescale at nuref in milliseconds.
+                                   Default: 0.01
                 alpha    (float) : power-law spectral index of the scattering timescale (freq scaling).
-                                   Default: 0.0
+                                   Default: -4.4
                 beta     (float) : spectral weighting index for frequency averaging.
-                                   Default: 0.0
+                                   Default: -1.6
                 nuref    (float) : reference frequency in MHz. Default: 600.0
-                tsamp    (float) : sampling time in milliseconds. Default: TSAMP * 1000
                 nbin     (int)   : number of phase bins in the profile. If None, uses
                                    len(self.phase_prof). Default: None
 
@@ -384,6 +393,7 @@ class Injection:
         bstart = bandmin + dnu / 2.0
         bend = bandmax - dnu / 2.0
         obsfreq = np.linspace(bstart, bend, nchan)
+        tsamp = 1000.0 / (self.f * nbin)
         t0 = np.arange(nbin) * tsamp
         nu = obsfreq[:, None]
         t = t0[None, :]
@@ -649,8 +659,12 @@ class Injection:
             scaled_prof_fft = scaled_prof_fft[:n_harm]
         else:
             n_harm = len(scaled_prof_fft)
-
-        scattered_prof_fft = self.scattering(scaled_prof_fft, n_harm=n_harm)
+        
+        scattered_prof_fft = self.scattering(
+            scaled_prof_fft, n_harm=n_harm,
+            tauref=self.tauref, alpha=self.alpha, beta=self.beta, nuref=self.nuref,
+        )
+        
         windowed_prof_fft = self.time_windowing(scattered_prof_fft)
         smeared_prof_fft = self.smear_fft(windowed_prof_fft)
 


### PR DESCRIPTION
Added a function to ps_inject that applies interstellar scattering. The implementation models scattering using the thin-screen approximation with an exponential pulse broadening function that scales with frequency. This is applied via convolution using a frequency-summed effective kernel, constructed by weighting per-channel pulse broadening functions according to a pulsar spectral index (beta) and summing across the CHIME band.

Adjustable parameters:
alpha : scattering spectral index
beta : pulsar spectral index
tauref : reference scattering timescale
nuref : reference frequency

Scattering can be disabled by setting tauref = 0.

This addition allows for more realistic injections by accounting for interstellar scattering.

This work is the core implementation of an undergraduate thesis completed at UBC.