### PR TITLE
Better injection select

### DIFF
--- a/champss/sps-common/sps_common/interfaces/ps_processes.py
+++ b/champss/sps-common/sps_common/interfaces/ps_processes.py
@@ -773,6 +773,9 @@ class Cluster:
     @classmethod
     def from_raw_detections(cls, detections):
         max_sig_det = detections[np.argmax(detections["sigma"])]
+        injection_index = max_sig_det["injection"]
+        if injection_index == -1:
+            injection_index = mode(detections["injection"]).mode
         init_dict = dict(
             max_sig_det=max_sig_det,
             freq=max_sig_det["freq"],
@@ -780,7 +783,7 @@ class Cluster:
             sigma=max_sig_det["sigma"],
             nharm=max_sig_det["nharm"],
             harm_idx=max_sig_det["harm_idx"],
-            injection_index=mode(detections["injection"]).mode,
+            injection_index=injection_index,
             detections=detections,
             manual_candidate=max_sig_det["manual_candidate"],
         )

--- a/champss/sps-common/sps_common/interfaces/ps_processes.py
+++ b/champss/sps-common/sps_common/interfaces/ps_processes.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from glob import glob
 from multiprocessing import shared_memory
 from typing import List
+from scipy.stats import mode
 
 import astropy.units as u
 import h5py
@@ -779,7 +780,7 @@ class Cluster:
             sigma=max_sig_det["sigma"],
             nharm=max_sig_det["nharm"],
             harm_idx=max_sig_det["harm_idx"],
-            injection_index=max_sig_det["injection"],
+            injection_index=mode(detections["injection"]).mode,
             detections=detections,
             manual_candidate=max_sig_det["manual_candidate"],
         )

--- a/champss/sps-common/sps_common/interfaces/single_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/single_pointing.py
@@ -621,7 +621,7 @@ class SinglePointingCandidateCollection:
 
     def test_injection_performance(self, verbose=True):
         """Return dict containing details fo the injection performance."""
-        injected_candidates = self.get_injection_candidates()
+        injected_candidates = self.get_search_injection_candidates()
         injected_indices = np.asarray(
             [cand.injection_dict["injection_index"] for cand in injected_candidates]
         )


### PR DESCRIPTION
This selects the injection index for one candidate by using the mode of the injection index when the max sigma detection has not been identified as an injection.

Also this fixed the injection performance test to not include manual candidates.