### PR TITLE
Improve injection plotting

### DIFF
--- a/champss/sps-common/sps_common/interfaces/multi_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/multi_pointing.py
@@ -16,6 +16,7 @@ from sps_common.constants import (
 )
 from sps_common.interfaces.single_pointing import (
     SinglePointingCandidate,
+    SinglePointingCandidateCollection,
 )
 from sps_common.interfaces.utilities import within_range
 from sps_common.plotting import plot_candidate
@@ -448,6 +449,22 @@ class MultiPointingCandidate:
         ]
         self.all_summaries = all_summaries
         return all_summaries
+
+    def get_spcc(self, index):
+        """Load a SinglePointingCandidateCollection based on an index."""
+        spcc = SinglePointingCandidateCollection.read(
+            self.all_spcc_files[index],
+        )
+        return spcc
+
+    def get_injections_in_spcc(self, index):
+        """Get all injections in a SinglePointingCandidateCollection based on an index."""
+        spcc = self.get_spcc(index)
+        return spcc.injections
+
+    def get_injection_in_best_observation(self):
+        """Get all injections in the SinglePointingCandidateCollection of the strongest candidate."""
+        return self.get_injections_in_spcc(0)
 
     def as_dict(self):
         """Return this candidate's properties as a Python dictionary."""

--- a/champss/sps-common/sps_common/interfaces/single_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/single_pointing.py
@@ -239,6 +239,8 @@ class SinglePointingCandidate:
             "dec": self.dec,
             "obs_id": self.obs_id,
             "datetimes": self.datetimes,
+            "injection": self.injection,
+            "any_injection_overlap": self.any_injection_overlap,
         }
         return out_dict
 

--- a/champss/sps-common/sps_common/plotting.py
+++ b/champss/sps-common/sps_common/plotting.py
@@ -57,7 +57,7 @@ def plot_text(fig, panel, grid_points, candidate):
                     getattr(candidate.best_candidate, value)
                 )
                 text += f"{value}: {val_string} \n"
-    ax_text.text(0, 1, text, ha="left", va="top", fontsize=10)
+    ax_text.text(0.1, 1, text, ha="left", va="top", fontsize=10,transform=ax_text.transAxes)
 
 
 def plot_dm_freq_3(fig, panel, grid_points, candidate):
@@ -236,7 +236,13 @@ def plot_raw_harm_all(fig, panel, grid_points, candidate):
     raw_powers = candidate.raw_harmonic_powers_array["powers"][:, :, 0]
     dm_values = candidate.raw_harmonic_powers_array["dms"]
 
-    ax_raw = fig.add_subplot(grid_points)
+    # Allows empty space above this plot. Manually added to make room for test without changing the grid
+    sgs = grid_points.subgridspec(
+        2, 1,
+        height_ratios=[0.2, 1]
+    )
+
+    ax_raw = fig.add_subplot(sgs[1])
     ax_raw.plot(dm_values, raw_powers, c="black")
     ax_raw.grid()
 


### PR DESCRIPTION
This PR adjusts the test and the raw harmonic plot to always show the full text.
In the multi-pointing plot there should never be an injection that was identified as an injection so there it not more space needed.

I also added some injection related fields to the candidate summary and added the convenience functions get_spcc, get_injections_in_spcc and get_injection_in_best_observation to MultiPointingCandidate. These make it a bit more convenient to load the underlying candidate collection to see if any injection might have played a role.


<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/d9969207-ae2d-44f1-a54a-75127187efbc" />
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/673a7f41-cd1d-44d7-af02-fa5dc6afe417" />
