### PR TITLE
fix injection distribution and do not use first bin for median scaling

### DIFF
--- a/champss/ps-processes/ps_processes/processes/ps_inject.py
+++ b/champss/ps-processes/ps_processes/processes/ps_inject.py
@@ -453,7 +453,7 @@ class Injection:
 
         for day in range(self.pspec_obj.num_days):
             day_medians = (
-                rn_medians[day] / np.min(rn_medians[day,:,1:], axis=1)[:, np.newaxis]
+                rn_medians[day] / np.min(rn_medians[day,:,5:], axis=1)[:, np.newaxis]
             )
             day_scales = rn_scales[day]
 

--- a/champss/ps-processes/ps_processes/processes/ps_inject.py
+++ b/champss/ps-processes/ps_processes/processes/ps_inject.py
@@ -75,7 +75,7 @@ def generate_injection(pspec, f_nyquist=508):
     # 24 is chosen as the maximum DM value at b = 90 deg from NE2001
     dm = np.random.choice(dm_spread, p=dm_weights)
 
-    S_choices = np.logspace(5e-2, 5e-1, 10000)
+    S_choices = np.logspace(np.log10(5e-2), np.log10(5e-1), 10000)
     S = np.random.choice(S_choices)
 
     prof_idx = np.random.choice(range(len(TPA_profiles.keys())))
@@ -453,7 +453,7 @@ class Injection:
 
         for day in range(self.pspec_obj.num_days):
             day_medians = (
-                rn_medians[day] / np.min(rn_medians[day], axis=1)[:, np.newaxis]
+                rn_medians[day] / np.min(rn_medians[day,:,1:], axis=1)[:, np.newaxis]
             )
             day_scales = rn_scales[day]
 


### PR DESCRIPTION
This PR fixes a bug where the edges of injection flux distribution were not set properly. This made the injections stronger than intended.

It also changed how the scaling of the red noise medians of the injections using the minimum is performed.
The first few recorded bin of the red noise medians, often have erratic behaviour, which when it is lower than the other bins, will also induce errativ behaviour in the injections. I remove the first 5 bins from the minimum calculation here.

This can create candidates like this
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/cd7fc43a-70bc-4ec3-b298-b9f1703d9303" />
The log of the underlying saved red noise medians looked like this.
<img width="432" height="336" alt="image" src="https://github.com/user-attachments/assets/6e8a3a5f-3e55-4f54-b700-455ec390183c" />

I checked for 2026/04/25 and there this had no effect on 80% of the observations.