### PR TITLE
Fix more manual candidate issues

### DIFF
--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -1022,7 +1022,7 @@ class PowerSpectraSearch:
                 if not search:
                     freq_indices = [np.argmin(np.abs(current_freq_labels - freq))]
                 else:
-                    freq_indices_bool = np.abs(current_freq_labels - freq) < 0.001
+                    freq_indices_bool = np.abs(current_freq_labels - freq) < 0.01
                     freq_indices = np.arange(len(current_freq_labels))[
                         freq_indices_bool
                     ]

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -1052,11 +1052,13 @@ class PowerSpectraSearch:
                             )
                             overlapped_injections.append(list_index)
                             all_injection_overlaps.append(injection_overlap_fraction)
-                    injection_overlap_fraction = np.max(all_injection_overlaps, initial=0.)
+                    injection_overlap_fraction = np.max(
+                        all_injection_overlaps, initial=0.0
+                    )
                 detection = (
                     current_freq_labels[freq_index],
                     pspec.dms[dm_index],
-                    1,
+                    harmonic,
                     tuple(np.pad(sorted_harm_bins, (0, 32 - len(sorted_harm_bins)))),
                     tuple(
                         np.pad(

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -1002,45 +1002,41 @@ class PowerSpectraSearch:
             used_full_harm_bins = self.full_harm_bins_raw
         all_harmonic_vals = np.array([1, 2, 4, 8, 16, 32])
         detections = []
-        dm_index = np.argmin(np.abs(pspec.dms - dm))
+        dm_index_ini = np.argmin(np.abs(pspec.dms - dm))
+        if not search:
+            dm_indices = [dm_index_ini]
+        else:
+            dm_search_range = 5
+            dm_start = max(dm_index_ini - dm_search_range, 0)
+            dm_end = min(dm_index_ini + dm_search_range, len(pspec.dms))
+            dm_indices = np.arange(dm_start, dm_end)
         if "Injection" in cand_description:
             injection_index = int(cand_description.split("_")[-1])
             injection_dict = injection_dicts[injection_index]
         else:
             injection_index = -1
-        for idx_harm, harmonic in enumerate(all_harmonic_vals):
-            current_freq_labels = pspec.freq_labels / harmonic
-            used_nsum = nsum_per_harmonic[idx_harm]
-            if not search:
-                freq_indices = [np.argmin(np.abs(current_freq_labels - freq))]
-            else:
-                freq_indices_bool = np.abs(current_freq_labels - freq) < 0.001
-                freq_indices = np.arange(len(current_freq_labels))[freq_indices_bool]
-            for freq_index in freq_indices:
-                sorted_harm_bins = sorted(
-                    used_full_harm_bins[:harmonic, freq_index].astype(int)
-                )
-                powers = pspec.power_spectra[dm_index, sorted_harm_bins]
-                powers_sum = powers.sum()
-                used_nsum_detec = used_nsum[freq_index]
-                sigma = sigma_sum_powers(powers_sum, used_nsum_detec)
-                # Check injection_overlap
-                injection_overlap_fraction = 0.0
-                if injection_index != -1:
-                    injected_bins = injection_dict["bins"]
-                    injected_dms = injection_dict["dms"]
-                    if dm_index in injected_dms:
-                        injection_overlap = np.intersect1d(
-                            sorted_harm_bins, injected_bins
-                        )
-                        injection_overlap_fraction = injection_overlap.size / len(
-                            sorted_harm_bins
-                        )
+        for dm_index in dm_indices:
+            for idx_harm, harmonic in enumerate(all_harmonic_vals):
+                current_freq_labels = pspec.freq_labels / harmonic
+                used_nsum = nsum_per_harmonic[idx_harm]
+                if not search:
+                    freq_indices = [np.argmin(np.abs(current_freq_labels - freq))]
                 else:
-                    # For manual candidates, that are not injections, only check if there is any overlap
-                    overlapped_injections = []
-                    all_injection_overlaps = []
-                    for list_index, injection_dict in enumerate(injection_dicts):
+                    freq_indices_bool = np.abs(current_freq_labels - freq) < 0.001
+                    freq_indices = np.arange(len(current_freq_labels))[
+                        freq_indices_bool
+                    ]
+                for freq_index in freq_indices:
+                    sorted_harm_bins = sorted(
+                        used_full_harm_bins[:harmonic, freq_index].astype(int)
+                    )
+                    powers = pspec.power_spectra[dm_index, sorted_harm_bins]
+                    powers_sum = powers.sum()
+                    used_nsum_detec = used_nsum[freq_index]
+                    sigma = sigma_sum_powers(powers_sum, used_nsum_detec)
+                    # Check injection_overlap
+                    injection_overlap_fraction = 0.0
+                    if injection_index != -1:
                         injected_bins = injection_dict["bins"]
                         injected_dms = injection_dict["dms"]
                         if dm_index in injected_dms:
@@ -1050,26 +1046,44 @@ class PowerSpectraSearch:
                             injection_overlap_fraction = injection_overlap.size / len(
                                 sorted_harm_bins
                             )
-                            overlapped_injections.append(list_index)
-                            all_injection_overlaps.append(injection_overlap_fraction)
-                    injection_overlap_fraction = np.max(
-                        all_injection_overlaps, initial=0.0
-                    )
-                detection = (
-                    current_freq_labels[freq_index],
-                    pspec.dms[dm_index],
-                    harmonic,
-                    tuple(np.pad(sorted_harm_bins, (0, 32 - len(sorted_harm_bins)))),
-                    tuple(
-                        np.pad(
-                            powers,
-                            (0, 32 - len(powers)),
+                    else:
+                        # For manual candidates, that are not injections, only check if there is any overlap
+                        overlapped_injections = []
+                        all_injection_overlaps = []
+                        for list_index, injection_dict in enumerate(injection_dicts):
+                            injected_bins = injection_dict["bins"]
+                            injected_dms = injection_dict["dms"]
+                            if dm_index in injected_dms:
+                                injection_overlap = np.intersect1d(
+                                    sorted_harm_bins, injected_bins
+                                )
+                                injection_overlap_fraction = (
+                                    injection_overlap.size / len(sorted_harm_bins)
+                                )
+                                overlapped_injections.append(list_index)
+                                all_injection_overlaps.append(
+                                    injection_overlap_fraction
+                                )
+                        injection_overlap_fraction = np.max(
+                            all_injection_overlaps, initial=0.0
                         )
-                    ),
-                    sigma,
-                    injection_index,
-                    injection_overlap_fraction,
-                    cand_description,
-                )
-                detections.append(detection)
+                    detection = (
+                        current_freq_labels[freq_index],
+                        pspec.dms[dm_index],
+                        harmonic,
+                        tuple(
+                            np.pad(sorted_harm_bins, (0, 32 - len(sorted_harm_bins)))
+                        ),
+                        tuple(
+                            np.pad(
+                                powers,
+                                (0, 32 - len(powers)),
+                            )
+                        ),
+                        sigma,
+                        injection_index,
+                        injection_overlap_fraction,
+                        cand_description,
+                    )
+                    detections.append(detection)
         return detections

--- a/champss/sps-common/sps_common/interfaces/ps_processes.py
+++ b/champss/sps-common/sps_common/interfaces/ps_processes.py
@@ -772,7 +772,10 @@ class Cluster:
 
     @classmethod
     def from_raw_detections(cls, detections):
-        max_sig_det = detections[np.argmax(detections["sigma"])]
+        try:
+            max_sig_det = detections[np.nanargmax(detections["sigma"])]
+        except ValueError:
+            max_sig_det = detections[0]
         injection_index = max_sig_det["injection"]
         if injection_index == -1:
             injection_index = mode(detections["injection"]).mode

--- a/champss/sps-common/sps_common/interfaces/single_pointing.py
+++ b/champss/sps-common/sps_common/interfaces/single_pointing.py
@@ -330,13 +330,19 @@ class SinglePointingCandidate:
     @property
     def best_harmonic_sum(self):
         """Returns the number of summed harmonics which results in the highest sigma."""
-        best_harmonic_sum_index = np.nanargmax(self.harm_sigma_curve) + 1
+        try:
+            best_harmonic_sum_index = np.nanargmax(self.harm_sigma_curve) + 1
+        except ValueError:
+            return np.nan
         return best_harmonic_sum_index
 
     @property
     def strongest_harmonic_frequency(self):
         """Returns the frequency of the harmonic which has the strongest raw power."""
-        strongest_harm_index = np.nanargmax(self.best_raw_harmonic_powers)
+        try:
+            strongest_harm_index = np.nanargmax(self.best_raw_harmonic_powers)
+        except ValueError:
+            return np.nan
         dm_index = np.nanargmin(np.abs(self.raw_harmonic_powers_array["dms"] - self.dm))
         freq_labels = self.raw_harmonic_powers_array["freqs"][dm_index, :, 0]
         strongest_freq = freq_labels[strongest_harm_index]
@@ -372,12 +378,15 @@ class SinglePointingCandidate:
     @property
     def masked_fraction_at_best_sigma(self):
         """Returns the fraction of masked bins at the the best weighted sigma."""
-        return (
-            1
-            - self.sigmas_per_harmonic_sum["weight_fraction"][
-                np.nanargmax(self.sigmas_per_harmonic_sum["sigmas_weighted"])
-            ]
-        )
+        try:
+            return (
+                1
+                - self.sigmas_per_harmonic_sum["weight_fraction"][
+                    np.nanargmax(self.sigmas_per_harmonic_sum["sigmas_weighted"])
+                ]
+            )
+        except ValueError:
+            return np.nan
 
     @property
     def sorted_datetimes(self):

--- a/champss/sps-pipeline/sps_pipeline/pipeline.py
+++ b/champss/sps-pipeline/sps_pipeline/pipeline.py
@@ -898,6 +898,24 @@ def main(
     type=str,
     help="Additional options that overwrite the config options. Provide a string that would define a python dictionary",
 )
+@click.option(
+    "--manual-candidates",
+    "--mc",
+    default=[],
+    type=str,
+    multiple=True,
+    help=(
+        "Allow retrieval of manual candidates. "
+        "Modes:"
+        "'--mc skip_search': Skip normal search; "
+        "'--mc para freq dm': Create candidate at freq and dm; "
+        "'--mc PSR psr_name': Create candidate at known source psr_name; "
+        "'--mc FS fs_id': Create candidate for followup source at given fs_id; "
+        "'--mc nearby_ks 1': Create candidate for all sources within given radius; "
+        "'--mc nearby_fs 1': Create candidate for followup sources within given radius; "
+        "'--mc injections': Create candidates for all injections; "
+    ),
+)
 def stack_and_search(
     plot,
     plot_threshold,
@@ -917,6 +935,7 @@ def stack_and_search(
     scale_injections,
     config_file,
     config_options,
+    manual_candidates,
 ):
     """
     Runner script to stack monthly PS into cumulative PS and search the eventual stack.
@@ -1005,6 +1024,7 @@ def stack_and_search(
             only_injections,
             scale_injections,
             file=file,
+            manual_candidates=manual_candidates,
         )
         if db_connection:
             ps_stack = db_api.get_ps_stack(closest_pointing_id)
@@ -1041,6 +1061,7 @@ def stack_and_search(
             injection_idx,
             only_injections,
             scale_injections,
+            manual_candidates=manual_candidates,
         )
         if to_search:
             if not ps_detections:

--- a/champss/sps-pipeline/sps_pipeline/ps_cumul_stack.py
+++ b/champss/sps-pipeline/sps_pipeline/ps_cumul_stack.py
@@ -15,6 +15,7 @@ def run(
     injection_idx=None,
     only_injections=False,
     scale_injections=False,
+    manual_candidates=[],
 ):
     """
     Run the power spectra stacking and searching process.
@@ -68,6 +69,7 @@ def run(
             injection_idx,
             only_injections,
             scale_injections,
+            manual_candidates=manual_candidates,
         )
     return ps_detections, power_spectra
 

--- a/champss/sps-pipeline/sps_pipeline/stack_scheduling.py
+++ b/champss/sps-pipeline/sps_pipeline/stack_scheduling.py
@@ -68,6 +68,7 @@ def find_monthly_search_commands(db_port, db_host, db_name, candpath, day_thresh
             "components": ["search-monthly"],
             "known_source_threshold": 10,
             "cand_path": candpath,
+            "manual_candidates": ["nearby_ks 0.5 search"],
         }
         all_commands.append(
             {


### PR DESCRIPTION
This PR fixes:

- Detections in manual candidates not containing the proper harmonci sum
- Some plots of manual candidates failing when too many np.nan are contained
- The candidate having nan sigma when one detection has such a sigma

This PR adds:

- Allows manual psr candidates to also search nearby DM trials for the maximum signal