### PR TITLE
update birdies based on stack candidates

### DIFF
--- a/champss/rfi-mitigation/rfi_mitigation/data/birdies.yaml
+++ b/champss/rfi-mitigation/rfi_mitigation/data/birdies.yaml
@@ -292,3 +292,9 @@ known_bad_frequencies:
     int_nharm: 8
     note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
     width: 0.01
+  b39:
+    frac_nharm: 0
+    frequency: 80
+    int_nharm: 2
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01

--- a/champss/rfi-mitigation/rfi_mitigation/data/birdies.yaml
+++ b/champss/rfi-mitigation/rfi_mitigation/data/birdies.yaml
@@ -256,3 +256,39 @@ known_bad_frequencies:
     int_nharm: 2
     frac_nharm: 0
     note: "Candidates in stacked spectra from 2026 02 run. Estimated from stack candidate frequency without barycentric correction."
+  b33:
+    frac_nharm: 0
+    frequency: 9.7658
+    int_nharm: 4
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01
+  b34:
+    frac_nharm: 0
+    frequency: 0.5208
+    int_nharm: 8
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01
+  b35:
+    frac_nharm: 0
+    frequency: 41.328
+    int_nharm: 8
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01
+  b36:
+    frac_nharm: 0
+    frequency: 0.1
+    int_nharm: 8
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01
+  b37:
+    frac_nharm: 0
+    frequency: 18.0185
+    int_nharm: 8
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01
+  b38:
+    frac_nharm: 0
+    frequency: 0.1333
+    int_nharm: 8
+    note: Candidates in stacked spectra from 2026 03 run. Estimated from stack candidate frequency without barycentric correction
+    width: 0.01


### PR DESCRIPTION
This PR updates the birdies based on the stack candidates.
These candidates were chosen based on looking the canddiates from the multi poinitng run which appeared in the most pointings. 

They all appear broadband in RFI and are not reliably filtered out by our RFI filter.

I checked the first one and it appeared to be broadband in the raw data, but was suppressed at DM=0 in the power spectra compared to the folds, possibly due to our detrending.

I could check whether the other sources could be filtered out by channel masking.

<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/92042c4e-45c0-4d59-b8e5-093306fe3649" />
<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/b44a5d55-e509-4b23-98e0-8094e45523ca" />
<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/254980da-22ec-48e6-a9fe-0c204b28854d" />
<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/187c4028-82f0-487b-8e88-b94910fe4fd5" />
<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/5648826e-5181-4895-990c-31a7509dfded" />
<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/1be0bcc5-b9bc-4c64-b5f9-f6e6de764a1a" />

The last few ones seemed to have appeared over a large sky area, but their number is relatively low. This may indicate that they get filtered otherwise. Could also not add them.