### PR TITLE
Optimize search loop

### DIFF
--- a/champss/ps-processes/ps_processes/processes/ps.py
+++ b/champss/ps-processes/ps_processes/processes/ps.py
@@ -307,6 +307,7 @@ class PowerSpectraCreation:
                 ),
                 zip(dm_indices, dedisp_series_list),
             )
+
             pool.close()
             pool.join()
             log.info("Power spectra creation successful.")

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -4,7 +4,7 @@ import logging
 import time
 from functools import partial
 import yaml
-from multiprocessing import Pool, shared_memory, set_start_method
+from multiprocessing import Pool, set_start_method
 import datetime
 import copy
 
@@ -33,6 +33,7 @@ from sps_common.interfaces.utilities import (
 from sps_common.constants import TSAMP
 from sps_databases import db_api
 from sps_common.interfaces import Cluster
+from sps_common.sm_utils import share_array, recreate_shared_array
 
 log = logging.getLogger(__name__)
 
@@ -217,6 +218,12 @@ class PowerSpectraSearch:
                     harmonic_sum(self.num_harm, np.zeros(ps_length_search))[1],
                 )
             ).astype(np.int32)
+        self.full_harm_bins, shm_full_harm_bins, shm_full_harm_bins_dict = share_array(
+            self.full_harm_bins
+        )
+        freq_labels, shm_freq_labels, shm_freq_labels_dict = share_array(
+            pspec.freq_labels
+        )
         # Manual candidates may want to exlcude the ks filter
         if self.full_harm_bins_raw is None and len(manual_candidates):
             # Could potentially add some protection against superflous copies
@@ -469,6 +476,14 @@ class PowerSpectraSearch:
             power_cutoff_per_harmonic = powersum_at_sigma(
                 self.sigma_min, nsum_per_harmonic
             )
+        nsum_per_harmonic, nsum_per_harmonic, shm_nsum_per_harmonic_dict = share_array(
+            nsum_per_harmonic
+        )
+        (
+            power_cutoff_per_harmonic,
+            shm_power_cutoff_per_harmonic,
+            shm_power_cutoff_per_harmonic_dict,
+        ) = share_array(power_cutoff_per_harmonic)
 
         if "skip_search" not in manual_candidates:
             pool = Pool(self.num_threads)
@@ -499,14 +514,12 @@ class PowerSpectraSearch:
             detection_list = pool.starmap(
                 partial(
                     self.search_candidates,
-                    pspec.power_spectra_shared.name,
-                    pspec.power_spectra.shape,
-                    pspec.power_spectra.dtype,
+                    pspec.power_spectra_shared_dict,
                     self.num_harm,
-                    self.full_harm_bins,
-                    pspec.freq_labels,
-                    nsum_per_harmonic,
-                    power_cutoff_per_harmonic,
+                    shm_full_harm_bins_dict,
+                    shm_freq_labels_dict,
+                    shm_nsum_per_harmonic_dict,
+                    shm_power_cutoff_per_harmonic_dict,
                     injection_dicts,
                     self.max_search_frequency,
                     self.skip_first_n_bins,
@@ -718,14 +731,12 @@ class PowerSpectraSearch:
 
     @staticmethod
     def search_candidates(
-        shared_spectra_name,
-        shared_spectra_shape,
-        shared_spectra_type,
+        shm_spec_dict,
         num_harm,
-        full_harm_bins,
-        freq_labels,
-        nsum_per_harmonic,
-        power_cutoff_per_harmonic,
+        shm_harm_bins_dict,
+        shm_freq_labels_dict,
+        shm_nsum_dict,
+        shm_power_dict,
         injection_dicts,
         cutoff_frequency,
         skip_n_bins,
@@ -789,9 +800,13 @@ class PowerSpectraSearch:
             made in the search process.
         """
         # log.debug(f"Working on DM={dm} with {num_harm} harmonics")
-        shared_spectra = shared_memory.SharedMemory(name=shared_spectra_name)
-        power_spectra = np.ndarray(
-            shared_spectra_shape, dtype=shared_spectra_type, buffer=shared_spectra.buf
+        # Could consider moving this to some initializer function
+        power_spectra, shared_spectra = recreate_shared_array(shm_spec_dict)
+        full_harm_bins, shm_full_harm_bins = recreate_shared_array(shm_harm_bins_dict)
+        freq_labels, shm_freq_labels = recreate_shared_array(shm_freq_labels_dict)
+        nsum_per_harmonic, shm_nsum_per_harmonic = recreate_shared_array(shm_nsum_dict)
+        power_cutoff_per_harmonic, shm_power_cutoff_per_harmonic = (
+            recreate_shared_array(shm_power_dict)
         )
         detection_list = []
         power_spectra = power_spectra[:, : len(full_harm_bins[0])]

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -33,7 +33,7 @@ from sps_common.interfaces.utilities import (
 from sps_common.constants import TSAMP
 from sps_databases import db_api
 from sps_common.interfaces import Cluster
-from sps_common.sm_utils import share_array, recreate_shared_array
+from sps_common.sm_utils import share_array, recreate_shared_array, unlink_shared
 
 log = logging.getLogger(__name__)
 
@@ -476,8 +476,8 @@ class PowerSpectraSearch:
             power_cutoff_per_harmonic = powersum_at_sigma(
                 self.sigma_min, nsum_per_harmonic
             )
-        nsum_per_harmonic, nsum_per_harmonic, shm_nsum_per_harmonic_dict = share_array(
-            nsum_per_harmonic
+        nsum_per_harmonic, shm_nsum_per_harmonic, shm_nsum_per_harmonic_dict = (
+            share_array(nsum_per_harmonic)
         )
         (
             power_cutoff_per_harmonic,
@@ -713,6 +713,11 @@ class PowerSpectraSearch:
             injection_dict_copy.pop("dms")
             injection_dict_copy.pop("injected_powers")
             injection_dicts_psdc.append(injection_dict_copy)
+
+        unlink_shared(shm_freq_labels)
+        unlink_shared(shm_full_harm_bins)
+        unlink_shared(shm_power_cutoff_per_harmonic)
+        unlink_shared(shm_nsum_per_harmonic)
         return (
             PowerSpectraDetectionClusters(
                 clusters=clusters,

--- a/champss/ps-processes/ps_processes/processes/ps_search.py
+++ b/champss/ps-processes/ps_processes/processes/ps_search.py
@@ -9,6 +9,7 @@ import datetime
 import copy
 
 import numpy as np
+from numba import njit
 import pandas as pd
 from attr import ib as attribute
 from attr import s as attrs
@@ -819,22 +820,26 @@ class PowerSpectraSearch:
         allowed_harmonics = [1, 2, 4, 8, 16, 32]
         for dm_index, dm in zip(dm_indices, dms):
             power_spectrum = power_spectra[dm_index, :]
-            for idx_harm, harm in enumerate(allowed_harmonics):
-                harm_start = time.time()
-                if harm > num_harm:
-                    continue
-                log.debug(f"Working on the harmonic={harm} sum")
-                harm_bins = full_harm_bins[:harm]
+            # for idx_harm, harm in enumerate(allowed_harmonics):
+            #     harm_start = time.time()
+            #     if harm > num_harm:
+            #         continue
+            #     log.debug(f"Working on the harmonic={harm} sum")
+            #     harm_bins = full_harm_bins[:harm]
 
-                if idx_harm == 0:
-                    harm_sum_powers = power_spectrum[harm_bins].sum(0)
-                else:
-                    last_harm = allowed_harmonics[idx_harm - 1]
-                    np.add(
-                        harm_sum_powers,
-                        power_spectrum[harm_bins[last_harm:harm, :]].sum(0),
-                        out=harm_sum_powers,
-                    )
+            #     if idx_harm == 0:
+            #         harm_sum_powers = power_spectrum[harm_bins].sum(0)
+            #     else:
+            #         last_harm = allowed_harmonics[idx_harm - 1]
+            #         np.add(
+            #             harm_sum_powers,
+            #             power_spectrum[harm_bins[last_harm:harm, :]].sum(0),
+            #             out=harm_sum_powers,
+            #         )
+            harmonic_sums = calc_harmonic_sum(power_spectrum, full_harm_bins)
+            for idx_harm, harm in enumerate(allowed_harmonics):
+                harm_bins = full_harm_bins[:harm]
+                harm_sum_powers = harmonic_sums[idx_harm]
 
                 power_cutoff = power_cutoff_per_harmonic[idx_harm]
                 used_nsum = nsum_per_harmonic[idx_harm]
@@ -979,10 +984,10 @@ class PowerSpectraSearch:
                         )
                     last_detection_freq = detection_freq
                     last_detection_sigma = sigma
-                harm_end = time.time()
-                log.debug(
-                    f"Took {harm_end - harm_start} seconds to do harmonic={harm} sum"
-                )
+                # harm_end = time.time()
+                # log.debug(
+                #     f"Took {harm_end - harm_start} seconds to do harmonic={harm} sum"
+                # )
         return detection_list
 
     def summarise(self, clusters, cluster_harm_idx):
@@ -1129,3 +1134,24 @@ class PowerSpectraSearch:
                     )
                     detections.append(detection)
         return detections
+
+
+@njit
+def calc_harmonic_sum(spec, harm_bins):
+    length = harm_bins.shape[1]
+
+    out = np.empty((6, length), dtype=spec.dtype)
+    s = np.zeros(length, dtype=spec.dtype)
+
+    out_idx = 0
+
+    for h in range(32):
+        for j in range(length):
+            s[j] += spec[harm_bins[h, j]]
+
+        if h == 0 or h == 1 or h == 3 or h == 7 or h == 15 or h == 31:
+            for j in range(length):
+                out[out_idx, j] = s[j]
+            out_idx += 1
+
+    return out

--- a/champss/sps-common/sps_common/interfaces/ps_processes.py
+++ b/champss/sps-common/sps_common/interfaces/ps_processes.py
@@ -23,6 +23,7 @@ from sps_common.interfaces.single_pointing import (
     SearchAlgorithm,
     check_detection_statistic,
 )
+from sps_common.sm_utils import share_array
 
 log = logging.getLogger(__name__)
 
@@ -206,6 +207,7 @@ class PowerSpectra:
     rn_scales = attrib(type=np.ndarray, default=None)
     rn_dm_indices = attrib(type=np.ndarray, default=None)
     power_spectra_shared = attrib(default=None)
+    power_spectra_shared_dict = attrib(default=None)
     injections = attrib(
         type=List, default=[]
     )  # Injections are not stored in the written hdf5
@@ -216,6 +218,12 @@ class PowerSpectra:
             self.dms = np.asarray(self.dms)
         if type(self.freq_labels) is not np.ndarray:
             self.freq_labels = np.asarray(self.freq_labels)
+        if self.power_spectra_shared is not None:
+            self.power_spectra_shared_dict = {
+                "name": self.power_spectra_shared.name,
+                "shape": self.power_spectra.shape,
+                "dtype": self.power_spectra.dtype,
+            }
 
     @power_spectra.validator
     def _validate_power_spectra_shape(self, attribute, value):
@@ -583,22 +591,16 @@ class PowerSpectra:
             self.power_spectra_shared.close()
             self.power_spectra_shared.unlink()
             self.power_spectra_shared = None
+            self.power_spectra_shared_dict = None
 
     def move_to_shared_memory(self):
-        """If not in shared memory, move to shared memory."""
+        """If not in shared memory, move to shared memory. Also check if shared dict exists."""
         if self.power_spectra_shared is None:
-            buffer_size = int(self.power_spectra.nbytes)
-            power_spectra_shared = shared_memory.SharedMemory(
-                create=True, size=buffer_size
-            )
-            power_spectra = np.ndarray(
-                self.power_spectra.shape,
-                dtype=self.power_spectra.dtype,
-                buffer=power_spectra_shared.buf,
-            )
-            power_spectra[:] = self.power_spectra
-            self.power_spectra = power_spectra
-            self.power_spectra_shared = power_spectra_shared
+            (
+                self.power_spectra,
+                self.power_spectra_shared,
+                self.power_spectra_shared_dict,
+            ) = share_array(self.power_spectra)
             log.info("Moved power spectra to shared memory.")
 
     def remove_injections(self):

--- a/champss/sps-common/sps_common/sm_utils.py
+++ b/champss/sps-common/sps_common/sm_utils.py
@@ -59,3 +59,8 @@ def recreate_shared_array(shm_dict):
     shm = shared_memory.SharedMemory(name=shm_dict["name"])
     array = np.ndarray(shm_dict["shape"], dtype=shm_dict["dtype"], buffer=shm.buf)
     return array, shm
+
+
+def unlink_shared(shm):
+    shm.close()
+    shm.unlink()

--- a/champss/sps-common/sps_common/sm_utils.py
+++ b/champss/sps-common/sps_common/sm_utils.py
@@ -1,0 +1,61 @@
+from multiprocessing import shared_memory
+import numpy as np
+
+
+def share_array(arr):
+    """
+    Move numpy array to shared memory.
+    Note that, this may lead to the array being present twice in memory. To prevent this
+    overwrite the old reference with the first output value.
+
+    arr, shm, shm_dict = share_array(arr)
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        The array that should be moved to shared memory
+
+    Returns
+    -------
+    array: np.ndarray
+        The new numpy array to access the array
+
+    shm: shared_memory.SharedMemory
+        The SharedMemory object of the new array
+
+    shm_dict: dict
+        The dict containing values needed for easy reconstruction of the array
+    """
+    buffer_size = arr.nbytes
+    shm = shared_memory.SharedMemory(create=True, size=buffer_size)
+
+    array = np.ndarray(
+        arr.shape,
+        dtype=arr.dtype,
+        buffer=shm.buf,
+    )
+    array[:] = arr
+    shm_dict = {"name": shm.name, "shape": array.shape, "dtype": array.dtype}
+    return array, shm, shm_dict
+
+
+def recreate_shared_array(shm_dict):
+    """
+    Recreate a shared memory array from a dict.
+
+    Parameters
+    ----------
+    shm_dict: dict
+        The dict as created by share_array.
+
+    Returns
+    -------
+    array: np.ndarray
+        The reconstructed numpy array
+
+    shm: shared_memory.SharedMemory
+        The SharedMemory object of the reconstructed array
+    """
+    shm = shared_memory.SharedMemory(name=shm_dict["name"])
+    array = np.ndarray(shm_dict["shape"], dtype=shm_dict["dtype"], buffer=shm.buf)
+    return array, shm

--- a/champss/sps-pipeline/pipeline-scripts/run_rednoise_benchmark.py
+++ b/champss/sps-pipeline/pipeline-scripts/run_rednoise_benchmark.py
@@ -1,23 +1,26 @@
 import numpy as np
 import matplotlib
-matplotlib.use('Agg')  # Use non-interactive backend
+
+matplotlib.use("Agg")  # Use non-interactive backend
 import matplotlib.pyplot as plt
 from glob import glob
 from sps_common.interfaces import rednoise_diagnostics
 import os
 
-median_pattern = './benchmark/2022/06/*/*/medians.npz'
+median_pattern = "./benchmark/2022/06/*/*/medians_0.npz"
 median_files = sorted(glob(median_pattern))
 
 if not median_files:
-    raise FileNotFoundError(f"No medians.npz files found matching pattern: {median_pattern}")
+    raise FileNotFoundError(
+        f"No medians.npz files found matching pattern: {median_pattern}"
+    )
 
 print(f"Found {len(median_files)} median files:")
 for f in median_files:
     print(f"  {f}")
 
 # Create output directory for plots
-output_dir = './benchmark/rednoise_plots'
+output_dir = "./benchmark/rednoise_plots"
 os.makedirs(output_dir, exist_ok=True)
 
 # Loop through all median files and create benchmark plots
@@ -25,21 +28,21 @@ for median_path in median_files:
     print(f"\nProcessing median file: {median_path}")
 
     info = np.load(median_path)
-    freq_labels = info['freq_labels']
-    DMs = info['dms']
-    medians = info['medians']
-    scales = info['scales']
+    freq_labels = info["freq_labels"]
+    DMs = info["dms"]
+    medians = info["medians"]
+    scales = info["scales"]
 
     # Extract date from path for plot title (e.g., ./benchmark/2022/06/18/...)
-    date_str = median_path.split('/')[3]  # Gets '18' from the path
-    title = f'Benchmark Rednoise Medians - 2022/06/{date_str}'
+    date_str = median_path.split("/")[3]  # Gets '18' from the path
+    title = f"Benchmark Rednoise Medians - 2022/06/{date_str}"
 
     # Plot medians (this will create the figure but not display it due to Agg backend)
     rednoise_diagnostics.plot_medians(freq_labels, DMs, medians, scales, title=title)
 
     # Save the plot
-    output_file = os.path.join(output_dir, f'rednoise_medians_202206{date_str}.png')
-    plt.savefig(output_file, dpi=150, bbox_inches='tight')
+    output_file = os.path.join(output_dir, f"rednoise_medians_202206{date_str}.png")
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
     plt.close()  # Close the figure to free memory
     print(f"Saved plot to: {output_file}")
 

--- a/champss/sps-pipeline/sps_pipeline/candidate_viewer.py
+++ b/champss/sps-pipeline/sps_pipeline/candidate_viewer.py
@@ -285,6 +285,15 @@ class CandidateViewerRegistrar:
             fold_plot = row.get("fold_plot", "")
             mdf_plot = row.get("mdf_path_to_plot", "")
             combined_plot = row.get("combined_plot_path", "")
+            # Sanitize nan
+            if stack_plot == "nan":
+                stack_plot = ""
+            if fold_plot == "nan":
+                fold_plot = ""
+            if mdf_plot == "nan":
+                mdf_plot = ""
+            if combined_plot == "nan":
+                combined_plot = ""
             input_file = row.get("file_name", "")
             fs_id = row.get("fs_id", "unknown")
             fs_sigma = row.get("fs_sigma", "unknown")


### PR DESCRIPTION
This PR optimizes the search loop, by

- Using shared memory for all arrays used in the search loop
- Use njit for performing the harmonic summing. In my earlier test of njit I only used it to gather the values needed for the sum but when I also use it for performing the sum, I see a performance boost.

I am not how much memory pressure this now creates, compared to the previous scheme, so I am not sure how the overall gain is but it should be a bit faster, especially when using more cores.